### PR TITLE
Add shopping list to task manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Features include:
 - Clickable day icons to mark completion, including optional completions on grey days.
 - One-off tasks list with due date editing, archive and delete options.
 - Recurring tasks list showing next due date, last completion and over/under metrics with skip or complete actions.
+- Shopping list section to track purchases with project, estimated cost and target month.
 - Projects can be closed when no open tasks reference them; closed projects are hidden from task forms.
 - Project list displays whether open tasks are allocated and only offers the close button when none are open.
 - Toast notifications appear when projects or tasks are added or modified.

--- a/data.json
+++ b/data.json
@@ -4,5 +4,6 @@
   "oneOffTasks": [],
   "recurringTasks": [],
   "deletedTasks": [],
+  "shoppingList": [],
   "nextId": 1
 }

--- a/index.html
+++ b/index.html
@@ -232,17 +232,35 @@ section {
     </div><!-- end recurringSection -->
   </section>
 
+  <section>
+    <div class="toggle section-header" onclick="toggle('shoppingSection')">Shopping List</div>
+    <div id="shoppingSection" class="hidden">
+      <div id="shoppingList"></div>
+      <div class="toggle add-toggle" onclick="toggle('addShopping')">Add Item</div>
+      <div id="addShopping" class="hidden subtoggle form-grid">
+        <label>Name<input type="text" id="shoppingName"></label>
+        <label>Project<select id="shoppingProject"></select></label>
+        <label>Est. Cost<input type="number" id="shoppingCost" step="0.01"></label>
+        <label>Month<input type="month" id="shoppingMonth"></label>
+        <div style="grid-column:1/-1;text-align:center;">
+          <button onclick="addShoppingItem()">Submit</button>
+        </div>
+      </div>
+    </div><!-- end shoppingSection -->
+  </section>
+
   <script>
 let projects = []; // {name, color, closed:false}
 let weeklyTasks = [];
 let oneOffTasks = [];
 let recurringTasks = [];
 let deletedTasks = [];
+let shoppingList = [];
 let nextId = 1;
 let currentWeekStart = startOfWeek(new Date());
 
 async function saveData() {
-  const data = { projects, weeklyTasks, oneOffTasks, recurringTasks, deletedTasks, nextId };
+  const data = { projects, weeklyTasks, oneOffTasks, recurringTasks, deletedTasks, shoppingList, nextId };
   try {
     await fetch('/api/data', {
       method: 'POST',
@@ -264,6 +282,7 @@ async function loadData() {
     oneOffTasks = obj.oneOffTasks || [];
     recurringTasks = obj.recurringTasks || [];
     deletedTasks = obj.deletedTasks || [];
+    shoppingList = obj.shoppingList || [];
     nextId = obj.nextId || 1;
   } catch (e) {
     console.error('Failed to load data', e);
@@ -341,7 +360,8 @@ function renderProjects() {
   const selects = [
     document.getElementById('weeklyProject'),
     document.getElementById('oneOffProject'),
-    document.getElementById('recurringProject')
+    document.getElementById('recurringProject'),
+    document.getElementById('shoppingProject')
   ];
   selects.forEach(sel => sel.innerHTML = '');
   projects.forEach(p => {
@@ -372,8 +392,10 @@ function renderProjects() {
 }
 
 function hasOpenTasks(projectName) {
-  const lists = [weeklyTasks, oneOffTasks, recurringTasks];
-  return lists.some(list => list.some(t => t.project === projectName && t.status === 'open'));
+  const taskLists = [weeklyTasks, oneOffTasks, recurringTasks];
+  if (taskLists.some(list => list.some(t => t.project === projectName && t.status === 'open')))
+    return true;
+  return shoppingList.some(i => i.project === projectName && !i.bought);
 }
 
 function closeProject(name) {
@@ -630,6 +652,73 @@ function editOneOffDue(id) {
   }
 }
 
+function addShoppingItem() {
+  const name = document.getElementById('shoppingName').value;
+  const project = document.getElementById('shoppingProject').value;
+  const cost = document.getElementById('shoppingCost').value;
+  const month = document.getElementById('shoppingMonth').value;
+  if (!name) return;
+  const proj = projects.find(p => p.name === project);
+  if (proj && proj.closed) return;
+  const item = {
+    id: String(nextId).padStart(8, '0'),
+    name, project, cost, month, bought: false
+  };
+  nextId++;
+  shoppingList.push(item);
+  document.getElementById('shoppingName').value = '';
+  document.getElementById('shoppingCost').value = '';
+  document.getElementById('shoppingMonth').value = '';
+  showMessage('Item added');
+  saveData();
+  renderShopping();
+}
+
+function renderShopping() {
+  const div = document.getElementById('shoppingList');
+  div.innerHTML = '';
+  if (shoppingList.length === 0) { div.textContent = 'No items'; return; }
+  const table = document.createElement('table');
+  table.className = 'task-table';
+  const head = document.createElement('tr');
+  head.innerHTML = '<th>Item</th><th>Project</th><th>Est. Cost</th><th>Month</th><th></th>';
+  table.appendChild(head);
+  shoppingList.forEach(it => {
+    const tr = document.createElement('tr');
+    const proj = projects.find(p => p.name === it.project);
+    const color = proj ? proj.color : '#000';
+    tr.innerHTML = `<td style="text-decoration:${it.bought?'line-through':'none'}">${it.name}</td><td style="color:${color}">${it.project}</td><td>${it.cost||''}</td><td>${it.month||''}</td>`;
+    const td = document.createElement('td');
+    const b = document.createElement('button');
+    b.textContent = it.bought ? 'Unbuy' : 'Bought';
+    b.onclick = () => toggleBoughtShopping(it.id);
+    const del = document.createElement('button');
+    del.textContent = 'Delete';
+    del.onclick = () => deleteShopping(it.id);
+    td.appendChild(b);
+    td.appendChild(del);
+    tr.appendChild(td);
+    table.appendChild(tr);
+  });
+  div.appendChild(table);
+}
+
+function toggleBoughtShopping(id) {
+  const item = shoppingList.find(i => i.id === id);
+  if (!item) return;
+  item.bought = !item.bought;
+  saveData();
+  renderShopping();
+}
+
+function deleteShopping(id) {
+  const idx = shoppingList.findIndex(i => i.id === id);
+  if (idx === -1) return;
+  shoppingList.splice(idx, 1);
+  saveData();
+  renderShopping();
+}
+
 function addRecurringTask() {
   const name = document.getElementById('recurringName').value;
   const project = document.getElementById('recurringProject').value;
@@ -796,6 +885,7 @@ async function init() {
   renderWeekly();
   renderOneOff();
   renderRecurring();
+  renderShopping();
   renderDeleted();
   renderArchived();
 }

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ const DB_NAME = process.env.MONGO_DB || 'taskdb';
 app.use(express.json());
 app.use(express.static(__dirname));
 
-let data = { projects: [], weeklyTasks: [], oneOffTasks: [], recurringTasks: [], deletedTasks: [], nextId: 1 };
+let data = { projects: [], weeklyTasks: [], oneOffTasks: [], recurringTasks: [], deletedTasks: [], shoppingList: [], nextId: 1 };
 let collection;
 const DATA_FILE = path.join(__dirname, 'data.json');
 let useMongo = !!MONGO_URI;


### PR DESCRIPTION
## Summary
- extend API storage schema to include `shoppingList`
- store an empty shopping list in initial data
- add Shopping List section on main page with toggle, form and list
- implement shopping list add/delete/bought functionality
- display projects for the shopping list in project list
- document the new feature in README

## Testing
- `npm start` *(fails: Unknown env config warning)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687bda870558832fa2b208d2d8bb93bd