### PR TITLE
Add navigation header and blank pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/diy.html
+++ b/diy.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>DIY</title>
+</head>
+<body>
+<header><h1>DIY</h1></header>
+<div id="nav-placeholder"></div>
+<script src="nav-loader.js"></script>
+<p>Content coming soon.</p>
+</body>
+</html>

--- a/gardening.html
+++ b/gardening.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Gardening</title>
+</head>
+<body>
+<header><h1>Gardening</h1></header>
+<div id="nav-placeholder"></div>
+<script src="nav-loader.js"></script>
+<p>Content coming soon.</p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -91,6 +91,8 @@ section {
   <header>
     <h1>Task Manager</h1>
   </header>
+<div id="nav-placeholder"></div>
+<script src="nav-loader.js"></script>
 
   <div id="toast" class="hidden"></div>
   <section>

--- a/nav-loader.js
+++ b/nav-loader.js
@@ -1,0 +1,8 @@
+function loadNav(){
+  fetch('nav.html')
+    .then(res => res.text())
+    .then(html => {
+      document.getElementById('nav-placeholder').innerHTML = html;
+    });
+}
+window.addEventListener('DOMContentLoaded', loadNav);

--- a/nav.html
+++ b/nav.html
@@ -1,0 +1,21 @@
+<nav class="main-nav">
+  <a href="index.html">ToDo</a>
+  <a href="shopping.html">Shopping</a>
+  <a href="gardening.html">Gardening</a>
+  <a href="diy.html">DIY</a>
+  <a href="work.html">Work</a>
+</nav>
+<style>
+  .main-nav {
+    display: flex;
+    gap: 1rem;
+    background: #eee;
+    padding: 0.5rem;
+    justify-content: center;
+  }
+  .main-nav a {
+    text-decoration: none;
+    color: #333;
+    padding: 0.25rem 0.5rem;
+  }
+</style>

--- a/server.js
+++ b/server.js
@@ -10,6 +10,11 @@ const MONGO_URI = process.env.MONGO_URI;
 const DB_NAME = process.env.MONGO_DB || 'taskdb';
 app.use(express.json());
 app.use(express.static(__dirname));
+app.get('/shopping', (req, res) => res.sendFile(path.join(__dirname, 'shopping.html')));
+app.get('/gardening', (req, res) => res.sendFile(path.join(__dirname, 'gardening.html')));
+app.get('/diy', (req, res) => res.sendFile(path.join(__dirname, 'diy.html')));
+app.get('/work', (req, res) => res.sendFile(path.join(__dirname, 'work.html')));
+app.get('/spending', (req, res) => res.sendFile(path.join(__dirname, 'spending.html')));
 
 let data = { projects: [], weeklyTasks: [], oneOffTasks: [], recurringTasks: [], deletedTasks: [], shoppingList: [], nextId: 1 };
 let collection;

--- a/shopping.html
+++ b/shopping.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Shopping</title>
+</head>
+<body>
+<header><h1>Shopping</h1></header>
+<div id="nav-placeholder"></div>
+<script src="nav-loader.js"></script>
+<p>Content coming soon.</p>
+</body>
+</html>

--- a/spending.html
+++ b/spending.html
@@ -1,9 +1,7 @@
 <body>
 <header><h1>Spending &amp; Finances</h1></header>
-<nav>
-  <a href="index.html">Tasks</a>
-  <a href="spending.html">Spending &amp; Finances</a>
-</nav>
+<div id="nav-placeholder"></div>
+<script src="nav-loader.js"></script>
 <section>
   <div class="toggle section-header" onclick="toggle('settings')">Settings</div>
   <div id="settings" class="hidden">

--- a/work.html
+++ b/work.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Work</title>
+</head>
+<body>
+<header><h1>Work</h1></header>
+<div id="nav-placeholder"></div>
+<script src="nav-loader.js"></script>
+<p>Content coming soon.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add shared navigation component
- load the nav on each page with a small loader script
- create blank Shopping, Gardening, DIY and Work pages
- wire new page routes in the express server
- ignore node_modules

## Testing
- `npm install`
- `npm start` (Server running)

------
https://chatgpt.com/codex/tasks/task_e_687bf699937c832fac5f95260a858a14