### PR TITLE
Fix local date display and recurring order

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,12 +295,16 @@ function startOfWeek(date) {
 }
 
 function formatISO(date) {
-  return date.toISOString().split('T')[0];
+  const d = new Date(date);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
 }
 function formatUK(date) {
   const d = new Date(date);
   if (isNaN(d)) return date || '';
-  return d.toLocaleDateString('en-GB');
+  return d.toLocaleDateString('en-GB', { day: '2-digit', month: 'long', year: '2-digit' });
 }
 function showMessage(msg) {
   const toast = document.getElementById("toast");
@@ -719,7 +723,9 @@ function computeNextDue(task, actionDate) {
 function renderRecurring() {
   const list = document.getElementById('recurringList');
   list.innerHTML = '';
-  const open = recurringTasks.filter(t => t.status === 'open');
+  const open = recurringTasks
+    .filter(t => t.status === 'open')
+    .sort((a, b) => new Date(a.dueDate) - new Date(b.dueDate));
   if (open.length === 0) { list.textContent = 'No recurring tasks'; return; }
   const table = document.createElement('table');
   table.className = 'task-table';

--- a/shopping.html
+++ b/shopping.html
@@ -7,7 +7,7 @@
 body { font-family: 'Segoe UI', Tahoma, sans-serif; margin: 0; padding: 0; }
 header {
   background: #fff;
-  color: #cc5500;
+  color: #ff69b4;
   padding: 1rem;
   text-align: center;
   border-bottom: 1px solid #ddd;

--- a/today.html
+++ b/today.html
@@ -47,8 +47,8 @@ let projects=[], weeklyTasks=[], oneOffTasks=[], recurringTasks=[], deletedTasks
 let todayList=[], todayTasks=[];
 let overdueTasks=[], dueTasks=[];
 let nextId=1;
-function formatISO(date){return date.toISOString().split('T')[0];}
-function formatUK(date){const d=new Date(date);if(isNaN(d)) return date||'';return d.toLocaleDateString('en-GB');}
+function formatISO(date){const d=new Date(date);const y=d.getFullYear();const m=String(d.getMonth()+1).padStart(2,'0');const day=String(d.getDate()).padStart(2,'0');return `${y}-${m}-${day}`;}
+function formatUK(date){const d=new Date(date);if(isNaN(d)) return date||'';return d.toLocaleDateString('en-GB',{day:'2-digit',month:'long',year:'2-digit'});}
 function startOfWeek(date){const d=new Date(date);const day=d.getDay();const diff=(day===0?-6:1-day);d.setDate(d.getDate()+diff);d.setHours(0,0,0,0);return d;}
 async function loadData(){try{const res=await fetch('/api/data');if(!res.ok) return;const obj=await res.json();projects=obj.projects||[];weeklyTasks=obj.weeklyTasks||[];oneOffTasks=obj.oneOffTasks||[];recurringTasks=obj.recurringTasks||[];deletedTasks=obj.deletedTasks||[];shoppingList=obj.shoppingList||[];longTermList=obj.longTermList||[];generalList=obj.generalList||[];todayList=obj.todayList||[];nextId=obj.nextId||1;}catch(e){console.error('Failed to load data',e);}}
 async function saveData(){const data={projects,weeklyTasks,oneOffTasks,recurringTasks,deletedTasks,shoppingList,longTermList,generalList,todayList,nextId};try{await fetch('/api/data',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}catch(e){console.error('Failed to save data',e);}}


### PR DESCRIPTION
## Summary
- format dates in local time on ToDo and Today pages
- display dates in `dd mmmm yy` format
- order recurring tasks by next due date
- match Shopping header style with other pages

## Testing
- `npm install`
- `npm start` (server starts)

------
https://chatgpt.com/codex/tasks/task_e_6886429fea10832f979f92891054d2b4