### PR TITLE
Add stretch and big tasks sections

### DIFF
--- a/diy.html
+++ b/diy.html
@@ -320,7 +320,9 @@ function renderTasks(){
     const row=document.createElement('div'); row.className='task-row'; row.style.marginLeft=depth+'rem'; row.draggable=true; row.ondragstart=ev=>startDrag(ev,t.id); row.ondragover=allowDrop; row.ondrop=ev=>dropOnTask(ev,t.id);
     row.innerHTML=`<div>${t.name}</div><div>${t.project}</div><div>${t.type}</div><div>${t.dueDate||''}</div><div>${t.urgent?'Y':'N'}</div>`;
     const ctrl=document.createElement('div'); ctrl.className='controls';
-    const infoBtn=document.createElement('button'); infoBtn.textContent='Info'; infoBtn.onclick=()=>alert(t.info||'');
+    const infoBtn=document.createElement('button');
+    infoBtn.textContent='Info';
+    infoBtn.onclick=()=>showInfo(t);
     const comp=document.createElement('button'); comp.textContent='Complete'; comp.onclick=()=>completeTask(t.id);
     const edit=document.createElement('button'); edit.textContent='Edit'; edit.onclick=()=>editTask(t.id);
     const sub=document.createElement('button'); sub.textContent='Add Sub'; sub.onclick=()=>addSubtask(t.id);
@@ -357,6 +359,9 @@ function initCalendar(){
 }
 function saveCalendar(){calendarEvents=calendar.getEvents().map(ev=>({id:ev.id,title:ev.title,start:ev.startStr,end:ev.endStr,taskId:ev.extendedProps.taskId||''})); saveData();}
 function deleteCalendarEvents(taskId){if(!calendar) return; calendar.getEvents().forEach(ev=>{if(ev.extendedProps.taskId===taskId) ev.remove();}); saveCalendar();}
+function showInfo(t){
+  alert(`Name: ${t.name}\nProject: ${t.project}\nType: ${t.type}\nDue: ${t.dueDate||''}\nUrgent: ${t.urgent?'Yes':'No'}\nInfo: ${t.info||''}`);
+}
 
 loadData();
 </script>

--- a/diy.html
+++ b/diy.html
@@ -115,6 +115,7 @@ let maxSubDepth=7;
 let calendarEvents=[];
 let calendarNextId=1;
 let calendar;
+let calendarDraggable=null;
 let pendingTask=null;
 let editingTask=null;
 let modalParent=null;
@@ -332,9 +333,21 @@ function renderTasks(){
 }
 
 function renderCalendarTasks(){
-  const cont=document.getElementById('calendarTaskList'); cont.innerHTML='';
-  forEachTask(t=>{ if(t.status!=='open') return; const div=document.createElement('div'); div.className='fc-task'; div.textContent=t.name; div.dataset.id=t.id; div.dataset.title=t.name; cont.appendChild(div); });
-  new FullCalendar.Draggable(cont,{itemSelector:'.fc-task',eventData:el=>({title:el.dataset.title,taskId:el.dataset.id})});
+  const cont=document.getElementById('calendarTaskList');
+  cont.innerHTML='';
+  forEachTask(t=>{
+    if(t.status!=='open') return;
+    const div=document.createElement('div');
+    div.className='fc-task';
+    div.textContent=t.name;
+    div.dataset.id=t.id;
+    div.dataset.title=t.name;
+    cont.appendChild(div);
+  });
+  if(calendarDraggable){
+    calendarDraggable.destroy();
+  }
+  calendarDraggable=new FullCalendar.Draggable(cont,{itemSelector:'.fc-task',eventData:el=>({title:el.dataset.title,taskId:el.dataset.id})});
 }
 
 function initCalendar(){

--- a/diy.html
+++ b/diy.html
@@ -3,19 +3,349 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>DIY</title>
+<title>DIY Tasks</title>
+<link href="https://cdn.jsdelivr.net/npm/fullcalendar@5.11.3/main.min.css" rel="stylesheet">
 <style>
-@media (max-width: 600px) {
-  html { font-size: 14px; }
-}
+body{font-family:'Segoe UI',Tahoma,sans-serif;margin:0;padding:0;}
+header{background:#fff;color:#ff69b4;padding:1rem;text-align:center;border-bottom:1px solid #ddd;}
+section{padding:1rem;border-bottom:10px solid pink;}
+.toggle{cursor:pointer;background:#f4f4f4;padding:0.5rem;border-radius:4px;margin:1rem 0;text-align:center;}
+.add-toggle{background:#eee;font-size:0.8rem;}
+.section-header{font-size:1.2rem;font-weight:bold;background:#cfe2ff;}
+.form-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:0.5rem;align-items:center;}
+.form-grid label{display:flex;flex-direction:column;font-size:0.9rem;}
+.form-grid input,.form-grid select,.form-grid textarea{width:100%;font-size:1rem;padding:0.4rem;}
+.hidden{display:none !important;}
+.task-row{display:grid;grid-template-columns:2fr 1fr 1fr 1fr 0.5fr;gap:0.25rem;align-items:center;border:1px solid #ccc;padding:0.25rem;margin-top:0.25rem;}
+.controls button{margin-left:0.25rem;font-size:0.7rem;}
+.filter-grid{display:flex;gap:0.5rem;flex-wrap:wrap;margin-bottom:0.5rem;}
+.calendar-container{display:flex;gap:1rem;flex-wrap:wrap;}
+#calendar{flex:1 1 300px;min-width:300px;}
+#calendarTaskList{flex:1 1 200px;min-width:200px;border:1px solid #ccc;padding:0.5rem;max-height:400px;overflow-y:auto;}
+.fc-task{background:#f4f4f4;margin:0.25rem 0;padding:0.25rem;border:1px solid #ccc;cursor:grab;}
+.modal{position:fixed;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.5);}
+.modal-content{background:#fff;padding:1rem;border-radius:4px;max-width:90%;width:320px;}
+.modal-content input,.modal-content textarea,.modal-content select{width:100%;margin-bottom:0.5rem;}
+@media (max-width:600px){html{font-size:14px;}}
 </style>
 </head>
 <body>
 <header>
-  <h1>DIY</h1>
+  <h1>DIY Tasks</h1>
   <div id="nav-placeholder"></div>
 </header>
 <script src="nav-loader.js"></script>
-<p>Content coming soon.</p>
+<script src="https://cdn.jsdelivr.net/npm/fullcalendar@5.11.3/main.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@fullcalendar/interaction@5.11.3/main.min.js"></script>
+
+
+<section>
+  <div class="toggle section-header" onclick="toggle('taskSection')">Tasks</div>
+  <div id="taskSection" class="hidden" ondragover="allowDrop(event)" ondrop="dropOnRoot(event)">
+    <div class="filter-grid">
+      <label>Project<select id="filterProject"><option value="all">All</option></select></label>
+      <label>Urgent<select id="filterUrgent"><option value="all">All</option><option value="yes">Yes</option><option value="no">No</option></select></label>
+      <button onclick="renderTasks()">Apply</button>
+    </div>
+    <div id="taskList"></div>
+    <div class="toggle add-toggle" onclick="toggle('addTaskForm')">Add Task</div>
+    <div id="addTaskForm" class="hidden form-grid">
+      <label>Name<input type="text" id="taskName"></label>
+      <label>Project<select id="taskProject"></select></label>
+      <label>Type<select id="taskType"></select></label>
+      <label>Due Date<input type="date" id="taskDue"></label>
+      <label><input type="checkbox" id="taskUrgent"> Urgent</label>
+      <label>Info<textarea id="taskInfo"></textarea></label>
+      <div style="grid-column:1/-1;text-align:center;">
+        <button onclick="addTask()">Submit</button>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<section>
+  <div class="toggle section-header" onclick="toggle('calendarSection')">Calendar</div>
+  <div id="calendarSection" class="hidden">
+    <div class="calendar-container">
+      <div id="calendar"></div>
+      <div>
+        <h3>Tasks</h3>
+        <div id="calendarTaskList"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="toggle section-header" onclick="toggle('projSection')">Projects & Types</div>
+  <div id="projSection" class="hidden">
+    <label>Project Name <input type="text" id="diyProjectName"></label>
+    <label>Color <input type="color" id="diyProjectColor" value="#ff0000"></label>
+    <button onclick="addDiyProject()">Add Project</button>
+    <label>New Type <input type="text" id="newType"></label>
+    <button onclick="addType()">Add Type</button>
+    <ul id="diyProjectList"></ul>
+    <ul id="typeList"></ul>
+  </div>
+</section>
+
+<div id="taskModal" class="modal hidden">
+  <div class="modal-content">
+    <label>Name<input id="taskModalName"></label>
+    <label>Project<select id="taskModalProject"></select></label>
+    <label>Type<select id="taskModalType"></select></label>
+    <label>Due Date<input type="date" id="taskModalDue"></label>
+    <label><input type="checkbox" id="taskModalUrgent"> Urgent</label>
+    <label>Info<textarea id="taskModalInfo"></textarea></label>
+    <div style="text-align:right;margin-top:0.5rem;">
+      <button onclick="saveTaskModal()">Save</button>
+      <button onclick="closeTaskModal()">Cancel</button>
+    </div>
+  </div>
+</div>
+
+<script>
+let store={};
+let diyProjects=[];
+let diyTypes=[];
+let diyTasks=[];
+let diyNextId=1;
+let maxSubDepth=7;
+let calendarEvents=[];
+let calendarNextId=1;
+let calendar;
+let pendingTask=null;
+let editingTask=null;
+let modalParent=null;
+
+function toggle(id){document.getElementById(id).classList.toggle('hidden');}
+
+async function loadData(){
+  try{
+    const res=await fetch('/api/diy-data');
+    if(res.ok){
+      store=await res.json();
+      diyProjects=store.diyProjects||[];
+      diyTypes=store.diyTypes||[];
+      diyTasks=store.diyTasks||[];
+      diyNextId=store.diyNextId||1;
+      maxSubDepth=store.maxSubDepth||7;
+      calendarEvents=store.calendarEvents||[];
+      calendarNextId=store.calendarNextId||1;
+    }
+    renderProjects();
+    renderTypes();
+    renderTasks();
+    renderCalendarTasks();
+    initCalendar();
+  }catch(e){console.error('load fail',e);}
+}
+
+async function saveData(){
+  store.diyProjects=diyProjects;
+  store.diyTypes=diyTypes;
+  store.diyTasks=diyTasks;
+  store.diyNextId=diyNextId;
+  store.maxSubDepth=maxSubDepth;
+  store.calendarEvents=calendarEvents;
+  store.calendarNextId=calendarNextId;
+  try{
+    await fetch('/api/diy-data',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(store)});
+  }catch(e){console.error('save fail',e);}
+}
+
+function addDiyProject(){
+  const name=document.getElementById('diyProjectName').value.trim();
+  const color=document.getElementById('diyProjectColor').value;
+  if(!name||diyProjects.find(p=>p.name===name)) return;
+  diyProjects.push({name,color});
+  document.getElementById('diyProjectName').value='';
+  renderProjects();
+  saveData();
+}
+
+function renderProjects(){
+  const ul=document.getElementById('diyProjectList');
+  const sel=document.getElementById('taskProject');
+  const sel2=document.getElementById('taskModalProject');
+  const filt=document.getElementById('filterProject');
+  ul.innerHTML=''; sel.innerHTML=''; sel2.innerHTML=''; filt.innerHTML='<option value="all">All</option>';
+  diyProjects.forEach(p=>{
+    const li=document.createElement('li'); li.style.color=p.color; li.textContent=p.name; ul.appendChild(li);
+    const opt=document.createElement('option'); opt.value=p.name; opt.textContent=p.name; sel.appendChild(opt); sel2.appendChild(opt.cloneNode(true));
+    const opt2=opt.cloneNode(true); filt.appendChild(opt2);
+  });
+}
+
+function addType(){
+  const t=document.getElementById('newType').value.trim();
+  if(!t||diyTypes.includes(t)) return;
+  diyTypes.push(t);
+  document.getElementById('newType').value='';
+  renderTypes();
+  saveData();
+}
+
+function renderTypes(){
+  const ul=document.getElementById('typeList');
+  const sel=document.getElementById('taskType');
+  const sel2=document.getElementById('taskModalType');
+  ul.innerHTML=''; sel.innerHTML=''; sel2.innerHTML='';
+  diyTypes.forEach(t=>{
+    const li=document.createElement('li'); li.textContent=t; ul.appendChild(li);
+    const opt=document.createElement('option'); opt.value=t; opt.textContent=t; sel.appendChild(opt); sel2.appendChild(opt.cloneNode(true));
+  });
+}
+
+function addTask(){
+  const name=document.getElementById('taskName').value.trim();
+  if(!name) return;
+  const task={
+    id:String(diyNextId).padStart(8,'0'),
+    parent:null,
+    name,
+    project:document.getElementById('taskProject').value,
+    type:document.getElementById('taskType').value,
+    dueDate:document.getElementById('taskDue').value,
+    urgent:document.getElementById('taskUrgent').checked,
+    info:document.getElementById('taskInfo').value,
+    status:'open',
+    subtasks:[]
+  };
+  diyNextId++;
+  diyTasks.push(task);
+  document.getElementById('taskName').value='';
+  document.getElementById('taskDue').value='';
+  document.getElementById('taskUrgent').checked=false;
+  document.getElementById('taskInfo').value='';
+  saveData();
+  renderTasks();
+  renderCalendarTasks();
+}
+
+function getTaskInfo(id,list=diyTasks,depth=0,parent=null){
+  for(const t of list){
+    if(t.id===id) return {task:t,parent,depth};
+    if(t.subtasks){const r=getTaskInfo(id,t.subtasks,depth+1,t); if(r) return r;}
+  }
+  return null;
+}
+
+function forEachTask(cb,list=diyTasks,depth=0,parent=null){
+  list.forEach(t=>{cb(t,depth,parent); if(t.subtasks) forEachTask(cb,t.subtasks,depth+1,t);});
+}
+
+function allowDrop(ev){ev.preventDefault();}
+let draggingTaskId=null;
+function startDrag(ev,id){draggingTaskId=id;}
+function dropOnTask(ev,targetId){ev.preventDefault(); if(draggingTaskId&&draggingTaskId!==targetId){changeParent(draggingTaskId,targetId);}}
+function dropOnRoot(ev){ev.preventDefault(); if(draggingTaskId){changeParent(draggingTaskId,null);}}
+
+function changeParent(taskId,newParentId){
+  const info=getTaskInfo(taskId); if(!info) return;
+  const newInfo=newParentId?getTaskInfo(newParentId):null;
+  if(newInfo && isDescendant(taskId,newParentId)){alert('Cannot move into descendant'); return;}
+  const newDepth=newInfo?newInfo.depth+1:0; if(newDepth>=maxSubDepth){alert('Max subtask depth reached'); return;}
+  if(info.parent){info.parent.subtasks=info.parent.subtasks.filter(t=>t!==info.task);} else {diyTasks=diyTasks.filter(t=>t!==info.task);} 
+  info.task.parent=newInfo?newInfo.task.id:null;
+  if(newInfo){newInfo.task.subtasks=newInfo.task.subtasks||[]; newInfo.task.subtasks.push(info.task);} else {diyTasks.push(info.task);} 
+  saveData(); renderTasks(); renderCalendarTasks();
+}
+
+function isDescendant(rootId,targetId){
+  const start=getTaskInfo(rootId); if(!start) return false;
+  const stack=[start.task];
+  while(stack.length){const t=stack.pop(); if(t.id===targetId) return true; if(t.subtasks) t.subtasks.forEach(s=>stack.push(s));}
+  return false;
+}
+
+function completeTask(id){
+  const info=getTaskInfo(id); if(!info) return; info.task.status='closed'; deleteCalendarEvents(id); saveData(); renderTasks(); renderCalendarTasks();
+}
+
+function deleteTask(id){
+  const info=getTaskInfo(id); if(!info) return;
+  if(confirm('Delete task?')){
+    if(info.parent){info.parent.subtasks=info.parent.subtasks.filter(t=>t!==info.task);}else{diyTasks=diyTasks.filter(t=>t!==info.task);} 
+    deleteCalendarEvents(id); saveData(); renderTasks(); renderCalendarTasks();
+  }
+}
+
+function editTask(id){const info=getTaskInfo(id); if(!info) return; openTaskModal(info.task,true);}
+function addSubtask(id){const info=getTaskInfo(id); if(!info) return; if(info.depth+1>=maxSubDepth){alert('Max subtask depth reached');return;} openTaskModal({project:info.task.project,type:info.task.type},false,info.task);}
+
+function openTaskModal(def={},isEdit=false,parent=null){
+  editingTask=isEdit?def:null; modalParent=parent;
+  pendingTask=Object.assign({name:'',project:'',type:'',dueDate:'',urgent:false,info:''},isEdit?def||{}:def||{});
+  const projSel=document.getElementById('taskModalProject'); projSel.innerHTML='';
+  diyProjects.forEach(p=>{const o=document.createElement('option');o.value=p.name;o.textContent=p.name;projSel.appendChild(o);});
+  const typeSel=document.getElementById('taskModalType'); typeSel.innerHTML=''; diyTypes.forEach(t=>{const o=document.createElement('option');o.value=t;o.textContent=t;typeSel.appendChild(o);});
+  document.getElementById('taskModalName').value=pendingTask.name;
+  document.getElementById('taskModalProject').value=pendingTask.project;
+  document.getElementById('taskModalType').value=pendingTask.type;
+  document.getElementById('taskModalDue').value=pendingTask.dueDate;
+  document.getElementById('taskModalUrgent').checked=pendingTask.urgent;
+  document.getElementById('taskModalInfo').value=pendingTask.info||'';
+  document.getElementById('taskModal').classList.remove('hidden');
+}
+
+function closeTaskModal(){document.getElementById('taskModal').classList.add('hidden'); pendingTask=null; editingTask=null; modalParent=null;}
+
+function saveTaskModal(){
+  if(!pendingTask) return;
+  const target=editingTask||pendingTask;
+  target.name=document.getElementById('taskModalName').value.trim();
+  target.project=document.getElementById('taskModalProject').value;
+  target.type=document.getElementById('taskModalType').value;
+  target.dueDate=document.getElementById('taskModalDue').value;
+  target.urgent=document.getElementById('taskModalUrgent').checked;
+  target.info=document.getElementById('taskModalInfo').value;
+  if(!editingTask){
+    const full={id:String(diyNextId).padStart(8,'0'),parent:modalParent?modalParent.id:null,status:'open',subtasks:[],...target};
+    diyNextId++;
+    if(modalParent){modalParent.subtasks=modalParent.subtasks||[];modalParent.subtasks.push(full);}else{diyTasks.push(full);} 
+  }
+  saveData(); renderTasks(); renderCalendarTasks(); closeTaskModal();
+}
+
+function renderTasks(){
+  const list=document.getElementById('taskList'); list.innerHTML='';
+  const fProj=document.getElementById('filterProject').value;
+  const fUrg=document.getElementById('filterUrgent').value;
+  function passes(t){ if(t.status!=='open') return false; if(fProj!=='all'&&t.project!==fProj) return false; if(fUrg==='yes'&&!t.urgent) return false; if(fUrg==='no'&&t.urgent) return false; return true; }
+  forEachTask((t,depth)=>{
+    if(!passes(t)) return;
+    const row=document.createElement('div'); row.className='task-row'; row.style.marginLeft=depth+'rem'; row.draggable=true; row.ondragstart=ev=>startDrag(ev,t.id); row.ondragover=allowDrop; row.ondrop=ev=>dropOnTask(ev,t.id);
+    row.innerHTML=`<div>${t.name}</div><div>${t.project}</div><div>${t.type}</div><div>${t.dueDate||''}</div><div>${t.urgent?'Y':'N'}</div>`;
+    const ctrl=document.createElement('div'); ctrl.className='controls';
+    const infoBtn=document.createElement('button'); infoBtn.textContent='Info'; infoBtn.onclick=()=>alert(t.info||'');
+    const comp=document.createElement('button'); comp.textContent='Complete'; comp.onclick=()=>completeTask(t.id);
+    const edit=document.createElement('button'); edit.textContent='Edit'; edit.onclick=()=>editTask(t.id);
+    const sub=document.createElement('button'); sub.textContent='Add Sub'; sub.onclick=()=>addSubtask(t.id);
+    const del=document.createElement('button'); del.textContent='Delete'; del.onclick=()=>deleteTask(t.id);
+    ctrl.appendChild(infoBtn); ctrl.appendChild(comp); ctrl.appendChild(edit); ctrl.appendChild(sub); ctrl.appendChild(del);
+    row.appendChild(ctrl);
+    list.appendChild(row);
+  });
+  renderCalendarTasks();
+}
+
+function renderCalendarTasks(){
+  const cont=document.getElementById('calendarTaskList'); cont.innerHTML='';
+  forEachTask(t=>{ if(t.status!=='open') return; const div=document.createElement('div'); div.className='fc-task'; div.textContent=t.name; div.dataset.id=t.id; div.dataset.title=t.name; cont.appendChild(div); });
+  new FullCalendar.Draggable(cont,{itemSelector:'.fc-task',eventData:el=>({title:el.dataset.title,taskId:el.dataset.id})});
+}
+
+function initCalendar(){
+  const el=document.getElementById('calendar');
+  calendar=new FullCalendar.Calendar(el,{initialView:'dayGridMonth',height:'auto',editable:true,droppable:true,eventDurationEditable:true,events:calendarEvents,eventReceive:info=>{info.event.setProp('id',String(calendarNextId++)); info.event.setExtendedProp('taskId',info.draggedEl.dataset.id); saveCalendar();},eventDrop:saveCalendar,eventResize:saveCalendar,eventClick:info=>{if(confirm('Remove this scheduled task?')){info.event.remove(); saveCalendar();}}});
+  calendar.render();
+}
+function saveCalendar(){calendarEvents=calendar.getEvents().map(ev=>({id:ev.id,title:ev.title,start:ev.startStr,end:ev.endStr,taskId:ev.extendedProps.taskId||''})); saveData();}
+function deleteCalendarEvents(taskId){if(!calendar) return; calendar.getEvents().forEach(ev=>{if(ev.extendedProps.taskId===taskId) ev.remove();}); saveCalendar();}
+
+loadData();
+</script>
 </body>
 </html>

--- a/diyData.json
+++ b/diyData.json
@@ -1,0 +1,9 @@
+{
+  "diyProjects": [],
+  "diyTypes": [],
+  "diyTasks": [],
+  "diyNextId": 1,
+  "maxSubDepth": 7,
+  "calendarEvents": [],
+  "calendarNextId": 1
+}

--- a/index.html
+++ b/index.html
@@ -100,24 +100,6 @@ section {
 <script src="nav-loader.js"></script>
 
   <div id="toast" class="hidden"></div>
-  <section>
-    <div class="toggle section-header" onclick="toggle('settings')">Settings</div>
-      <div id="settings" class="hidden">
-        <h3>Add Project</h3>
-        <input type="text" id="projectName" placeholder="Project name">
-        <input type="color" id="projectColor" value="#ff0000">
-        <button onclick="addProject()">Add</button>
-        <ul id="projects"></ul>
-        <button onclick="toggle('deletedBox')">Deleted Tasks</button>
-        <div id="deletedBox" class="hidden box">
-          <ul id="deletedList"></ul>
-        </div>
-        <button onclick="toggle('archivedBox')">Archived Tasks</button>
-        <div id="archivedBox" class="hidden box">
-          <ul id="archivedList"></ul>
-        </div>
-      </div>
-  </section>
 
   <section>
     <div class="toggle section-header" onclick="toggle('weeklySection')">Weekly Tasks</div>
@@ -301,6 +283,24 @@ section {
     </div><!-- end bigSection -->
   </section>
 
+  <section>
+    <div class="toggle section-header" onclick="toggle('settings')">Settings</div>
+      <div id="settings" class="hidden">
+        <h3>Add Project</h3>
+        <input type="text" id="projectName" placeholder="Project name">
+        <input type="color" id="projectColor" value="#ff0000">
+        <button onclick="addProject()">Add</button>
+        <ul id="projects"></ul>
+        <button onclick="toggle('deletedBox')">Deleted Tasks</button>
+        <div id="deletedBox" class="hidden box">
+          <ul id="deletedList"></ul>
+        </div>
+        <button onclick="toggle('archivedBox')">Archived Tasks</button>
+        <div id="archivedBox" class="hidden box">
+          <ul id="archivedList"></ul>
+        </div>
+      </div>
+  </section>
 
 
   <script>

--- a/index.html
+++ b/index.html
@@ -60,7 +60,8 @@ section {
   justify-content: center;
 }
 .task-info { display: flex; flex-direction: column; text-align: left; align-items: flex-start; justify-content: flex-start; }
-.task-info div { padding: 0.05rem 0; }
+.task-info div { padding: 0.05rem 0; border:none; }
+.task-meta.small { font-size: 0.6rem; }
 .task-name { font-size: 0.9rem; }
 .task-meta { font-size: 0.7rem; }
 .circle {
@@ -241,6 +242,65 @@ section {
     </div><!-- end recurringSection -->
   </section>
 
+  <section>
+    <div class="toggle section-header" onclick="toggle('stretchSection')">Stretch Tasks</div>
+    <div id="stretchSection">
+    <div id="stretchList"></div>
+    <div class="toggle add-toggle" onclick="toggle('addStretch')">Add Stretch Task</div>
+    <div id="addStretch" class="hidden subtoggle form-grid">
+      <label>Name<input type="text" id="stretchName"></label>
+      <label>Project<select id="stretchProject"></select></label>
+      <label>Importance<select id="stretchImportance">
+        <option>High</option>
+        <option>High/Medium</option>
+        <option>Medium</option>
+        <option>Medium/Low</option>
+        <option>Low</option>
+      </select></label>
+      <label>Urgency<select id="stretchUrgency">
+        <option>High</option>
+        <option>High/Medium</option>
+        <option>Medium</option>
+        <option>Medium/Low</option>
+        <option>Low</option>
+      </select></label>
+      <div style="grid-column:1/-1;text-align:center;">
+        <button onclick="addStretchTask()">Submit</button>
+      </div>
+    </div>
+    </div><!-- end stretchSection -->
+  </section>
+
+  <section>
+    <div class="toggle section-header" onclick="toggle('bigSection')">Big Tasks &amp; Goals</div>
+    <div id="bigSection">
+    <div id="bigList"></div>
+    <div class="toggle add-toggle" onclick="toggle('addBig')">Add Big Task</div>
+    <div id="addBig" class="hidden subtoggle form-grid">
+      <label>Name<input type="text" id="bigName"></label>
+      <label>Project<select id="bigProject"></select></label>
+      <label>Importance<select id="bigImportance">
+        <option>High</option>
+        <option>High/Medium</option>
+        <option>Medium</option>
+        <option>Medium/Low</option>
+        <option>Low</option>
+      </select></label>
+      <label>Urgency<select id="bigUrgency">
+        <option>High</option>
+        <option>High/Medium</option>
+        <option>Medium</option>
+        <option>Medium/Low</option>
+        <option>Low</option>
+      </select></label>
+      <label>Due Date<input type="date" id="bigDue"></label>
+      <div style="grid-column:1/-1;text-align:center;">
+        <button onclick="addBigTask()">Submit</button>
+      </div>
+    </div>
+    </div><!-- end bigSection -->
+  </section>
+
 
 
   <script>
@@ -248,6 +308,8 @@ let projects = []; // {name, color, closed:false}
 let weeklyTasks = [];
 let oneOffTasks = [];
 let recurringTasks = [];
+let stretchTasks = [];
+let bigTasks = [];
 let deletedTasks = [];
 let shoppingList = [];
 let longTermList = [];
@@ -257,7 +319,7 @@ let nextId = 1;
 let currentWeekStart = startOfWeek(new Date());
 
 async function saveData() {
-  const data = { projects, weeklyTasks, oneOffTasks, recurringTasks, deletedTasks, shoppingList, longTermList, generalList, todayList, nextId };
+  const data = { projects, weeklyTasks, oneOffTasks, recurringTasks, stretchTasks, bigTasks, deletedTasks, shoppingList, longTermList, generalList, todayList, nextId };
   try {
     await fetch('/api/index-data', {
       method: 'POST',
@@ -278,6 +340,8 @@ async function loadData() {
     weeklyTasks = obj.weeklyTasks || [];
     oneOffTasks = obj.oneOffTasks || [];
     recurringTasks = obj.recurringTasks || [];
+    stretchTasks = obj.stretchTasks || [];
+    bigTasks = obj.bigTasks || [];
     deletedTasks = obj.deletedTasks || [];
     shoppingList = obj.shoppingList || [];
     longTermList = obj.longTermList || [];
@@ -370,7 +434,9 @@ function renderProjects() {
   const selects = [
     document.getElementById('weeklyProject'),
     document.getElementById('oneOffProject'),
-    document.getElementById('recurringProject')
+    document.getElementById('recurringProject'),
+    document.getElementById('stretchProject'),
+    document.getElementById('bigProject')
   ];
   selects.forEach(sel => sel.innerHTML = '');
   projects.forEach(p => {
@@ -401,7 +467,7 @@ function renderProjects() {
 }
 
 function hasOpenTasks(projectName) {
-  const taskLists = [weeklyTasks, oneOffTasks, recurringTasks];
+  const taskLists = [weeklyTasks, oneOffTasks, recurringTasks, stretchTasks, bigTasks];
   if (taskLists.some(list => list.some(t => t.project === projectName && t.status === 'open')))
     return true;
   return shoppingList.some(i => i.project === projectName && !i.bought);
@@ -492,13 +558,17 @@ function taskCell(task) {
   nameDiv.className = 'task-name';
   nameDiv.textContent = task.name;
 
+  if ((task.project || '').toLowerCase().includes('self care')) {
+    nameDiv.style.fontWeight = 'bold';
+  }
+
   const projectDiv = document.createElement('div');
   projectDiv.className = 'task-meta';
   projectDiv.style.color = color;
   projectDiv.textContent = task.project;
 
   const metaDiv = document.createElement('div');
-  metaDiv.className = 'task-meta';
+  metaDiv.className = 'task-meta small';
   metaDiv.textContent = `Importance: ${task.importance} | Urgency: ${task.urgency}`;
 
   const controls = document.createElement('div');
@@ -676,6 +746,193 @@ function editOneOffDue(id) {
   }
 }
 
+function addStretchTask() {
+  const name = document.getElementById('stretchName').value;
+  const project = document.getElementById('stretchProject').value;
+  const importance = document.getElementById('stretchImportance').value;
+  const urgency = document.getElementById('stretchUrgency').value;
+  if (!name) return;
+  const proj = projects.find(p => p.name === project);
+  if (proj && proj.closed) return;
+  const task = {
+    id: String(nextId).padStart(8, '0'),
+    name, project, importance, urgency,
+    completedDates: [],
+    status: 'open'
+  };
+  nextId++;
+  stretchTasks.push(task);
+  document.getElementById('stretchName').value = '';
+  showMessage("Task added");
+  saveData();
+  renderStretch();
+}
+
+function renderStretch() {
+  const list = document.getElementById('stretchList');
+  list.innerHTML = '';
+  const open = stretchTasks.filter(t => t.status === 'open');
+  if (open.length === 0) { list.textContent = 'No stretch tasks'; return; }
+  const table = document.createElement('table');
+  table.className = 'task-table';
+  const head = document.createElement('tr');
+  head.innerHTML = '<th>Task</th><th>Project</th><th>Last Done</th><th></th>';
+  table.appendChild(head);
+  open.forEach(t => {
+    const tr = document.createElement('tr');
+    const proj = projects.find(p => p.name === t.project);
+    const color = proj ? proj.color : '#000';
+    const last = t.completedDates.length ? formatUK(t.completedDates[t.completedDates.length-1]) : '';
+    tr.innerHTML = `<td>${t.name}</td><td style="color:${color}">${t.project}</td><td>${last}</td>`;
+    const td = document.createElement('td');
+    const log = document.createElement('button');
+    log.textContent = 'Log';
+    log.onclick = () => logStretch(t.id);
+    const del = document.createElement('button');
+    del.textContent = 'Delete';
+    del.onclick = () => deleteStretch(t.id);
+    td.appendChild(log);
+    td.appendChild(del);
+    tr.appendChild(td);
+    table.appendChild(tr);
+  });
+  list.appendChild(table);
+}
+
+function logStretch(id) {
+  const task = stretchTasks.find(t => t.id === id);
+  if (!task) return;
+  task.completedDates.push(formatISO(new Date()));
+  saveData();
+  renderStretch();
+}
+
+function deleteStretch(id) {
+  const idx = stretchTasks.findIndex(t => t.id === id);
+  if (idx === -1) return;
+  if (confirm('Delete this task permanently?')) {
+    deletedTasks.push(stretchTasks[idx]);
+    stretchTasks.splice(idx, 1);
+    saveData();
+    renderStretch();
+    renderDeleted();
+  }
+}
+
+function addBigTask() {
+  const name = document.getElementById('bigName').value;
+  const project = document.getElementById('bigProject').value;
+  const importance = document.getElementById('bigImportance').value;
+  const urgency = document.getElementById('bigUrgency').value;
+  const due = document.getElementById('bigDue').value;
+  if (!name) return;
+  const proj = projects.find(p => p.name === project);
+  if (proj && proj.closed) return;
+  const task = {
+    id: String(nextId).padStart(8, '0'),
+    name, project, importance, urgency,
+    dueDate: due,
+    startDate: formatISO(new Date()),
+    status: 'open',
+    closedDate: '',
+    taskType: 'Big',
+    completedDates: [],
+    missedDates: []
+  };
+  nextId++;
+  bigTasks.push(task);
+  document.getElementById('bigName').value = '';
+  document.getElementById('bigDue').value = '';
+  showMessage("Task added");
+  saveData();
+  renderBig();
+}
+
+function renderBig() {
+  const list = document.getElementById('bigList');
+  list.innerHTML = '';
+  const open = bigTasks.filter(t => t.status === 'open');
+  if (open.length === 0) { list.textContent = 'No big tasks'; return; }
+  const table = document.createElement('table');
+  table.className = 'task-table';
+  const head = document.createElement('tr');
+  head.innerHTML = '<th>Task</th><th>Project</th><th>Due</th><th></th>';
+  table.appendChild(head);
+  open.forEach(t => {
+    const tr = document.createElement('tr');
+    const proj = projects.find(p => p.name === t.project);
+    const color = proj ? proj.color : '#000';
+    tr.innerHTML = `<td>${t.name}</td><td style="color:${color}">${t.project}</td><td>${t.dueDate?formatUK(t.dueDate):''}</td>`;
+    const td = document.createElement('td');
+    const comp = document.createElement('button');
+    comp.textContent = 'Complete';
+    comp.onclick = () => completeBig(t.id);
+    const edit = document.createElement('button');
+    edit.textContent = 'Edit Due';
+    edit.onclick = () => editBigDue(t.id);
+    const closeB = document.createElement('button');
+    closeB.textContent = 'Archive';
+    closeB.onclick = () => closeBig(t.id);
+    const del = document.createElement('button');
+    del.textContent = 'Delete';
+    del.onclick = () => deleteBig(t.id);
+    td.appendChild(comp);
+    td.appendChild(edit);
+    td.appendChild(closeB);
+    td.appendChild(del);
+    tr.appendChild(td);
+    table.appendChild(tr);
+  });
+  list.appendChild(table);
+}
+
+function completeBig(id) {
+  const task = bigTasks.find(t => t.id === id);
+  if (!task) return;
+  task.completedDates.push(formatISO(new Date()));
+  task.status = 'closed';
+  task.closedDate = formatISO(new Date());
+  saveData();
+  renderBig();
+  renderArchived();
+}
+
+function closeBig(id) {
+  const task = bigTasks.find(t => t.id === id);
+  if (!task) return;
+  if (confirm('You are about to close this task. Continue?')) {
+    task.status = 'closed';
+    task.closedDate = formatISO(new Date());
+    saveData();
+    renderBig();
+    renderArchived();
+  }
+}
+
+function deleteBig(id) {
+  const idx = bigTasks.findIndex(t => t.id === id);
+  if (idx === -1) return;
+  if (confirm('Delete this task permanently?')) {
+    deletedTasks.push(bigTasks[idx]);
+    bigTasks.splice(idx, 1);
+    saveData();
+    renderBig();
+    renderDeleted();
+    renderArchived();
+  }
+}
+
+function editBigDue(id) {
+  const task = bigTasks.find(t => t.id === id);
+  if (!task) return;
+  const newDate = prompt('New due date (YYYY-MM-DD):', task.dueDate);
+  if (newDate !== null) {
+    task.dueDate = newDate;
+    saveData();
+    renderBig();
+  }
+}
+
 
 function addRecurringTask() {
   const name = document.getElementById('recurringName').value;
@@ -829,7 +1086,7 @@ function renderArchived() {
   const list = document.getElementById('archivedList');
   if (!list) return;
   list.innerHTML = '';
-  const closed = [...weeklyTasks, ...oneOffTasks, ...recurringTasks].filter(t => t.status === 'closed');
+  const closed = [...weeklyTasks, ...oneOffTasks, ...recurringTasks, ...bigTasks].filter(t => t.status === 'closed');
   closed.forEach(t => {
     const li = document.createElement('li');
     li.textContent = `${t.name} (${t.project})`;
@@ -844,6 +1101,8 @@ async function init() {
   renderProjects();
   renderWeekly();
   renderOneOff();
+  renderStretch();
+  renderBig();
   renderRecurring();
   renderDeleted();
   renderArchived();

--- a/indexData.json
+++ b/indexData.json
@@ -3,6 +3,8 @@
   "weeklyTasks": [],
   "oneOffTasks": [],
   "recurringTasks": [],
+  "stretchTasks": [],
+  "bigTasks": [],
   "deletedTasks": [],
   "shoppingList": [],
   "longTermList": [],

--- a/server.js
+++ b/server.js
@@ -19,6 +19,8 @@ let indexData = {
   weeklyTasks: [],
   oneOffTasks: [],
   recurringTasks: [],
+  stretchTasks: [],
+  bigTasks: [],
   deletedTasks: [],
   shoppingList: [],
   longTermList: [],

--- a/server.js
+++ b/server.js
@@ -41,6 +41,17 @@ let workData = {
   meetingNextId: 1
 };
 
+// diy page data
+let diyData = {
+  diyProjects: [],
+  diyTypes: [],
+  diyTasks: [],
+  diyNextId: 1,
+  maxSubDepth: 7,
+  calendarEvents: [],
+  calendarNextId: 1
+};
+
 // spending page data
 let spendingData = {
   projects: [],
@@ -53,6 +64,7 @@ let spendingData = {
 const INDEX_FILE = path.join(__dirname, 'indexData.json');
 const WORK_FILE = path.join(__dirname, 'workData.json');
 const SPENDING_FILE = path.join(__dirname, 'spendingData.json');
+const DIY_FILE = path.join(__dirname, 'diyData.json');
 
 function loadJson(file, def) {
   if (fs.existsSync(file)) {
@@ -71,6 +83,7 @@ function initDb() {
   indexData = loadJson(INDEX_FILE, indexData);
   workData = loadJson(WORK_FILE, workData);
   spendingData = loadJson(SPENDING_FILE, spendingData);
+  diyData = loadJson(DIY_FILE, diyData);
 }
 
 app.get('/api/index-data', (req, res) => {
@@ -100,6 +113,16 @@ app.get('/api/spending-data', (req, res) => {
 app.post('/api/spending-data', (req, res) => {
   spendingData = req.body;
   fs.writeFileSync(SPENDING_FILE, JSON.stringify(spendingData, null, 2));
+  res.json({ status: 'ok' });
+});
+
+app.get('/api/diy-data', (req, res) => {
+  res.json(diyData);
+});
+
+app.post('/api/diy-data', (req, res) => {
+  diyData = req.body;
+  fs.writeFileSync(DIY_FILE, JSON.stringify(diyData, null, 2));
   res.json({ status: 'ok' });
 });
 

--- a/spending.html
+++ b/spending.html
@@ -5,20 +5,6 @@
 </header>
 <script src="nav-loader.js"></script>
 <section>
-  <div class="toggle section-header" onclick="toggle('settings')">Settings</div>
-  <div id="settings" class="hidden">
-    <h3>Add Project</h3>
-    <input type="text" id="projectName" placeholder="Project name">
-    <input type="color" id="projectColor" value="#ff0000">
-    <button onclick="addProject()">Add</button>
-    <ul id="projects"></ul>
-    <h3>Filter Projects</h3>
-    <select id="projectFilter" multiple></select>
-    <button onclick="applyFilter()">Apply</button>
-    <button onclick="resetFilter()">Reset</button>
-  </div>
-</section>
-<section>
   <div class="toggle section-header" onclick="toggle('shoppingSection')">Shopping List</div>
   <div id="shoppingSection" class="hidden">
     <div id="shoppingList"></div>
@@ -58,6 +44,20 @@
         <button onclick="addCanBuyItem()">Submit</button>
       </div>
     </div>
+  </div>
+</section>
+<section>
+  <div class="toggle section-header" onclick="toggle('settings')">Settings</div>
+  <div id="settings" class="hidden">
+    <h3>Add Project</h3>
+    <input type="text" id="projectName" placeholder="Project name">
+    <input type="color" id="projectColor" value="#ff0000">
+    <button onclick="addProject()">Add</button>
+    <ul id="projects"></ul>
+    <h3>Filter Projects</h3>
+    <select id="projectFilter" multiple></select>
+    <button onclick="applyFilter()">Apply</button>
+    <button onclick="resetFilter()">Reset</button>
   </div>
 </section>
 <script>

--- a/today.html
+++ b/today.html
@@ -41,6 +41,8 @@ header {
     <ul id="dueList" class="task-list"></ul>
     <label style="display:block;margin-top:0.5rem;"><input type="checkbox" id="workToggle"> Show Work Tasks</label>
     <ul id="workTaskList" class="task-list hidden"></ul>
+    <label style="display:block;margin-top:0.5rem;"><input type="checkbox" id="diyToggle"> Show DIY Tasks</label>
+    <ul id="diyTaskList" class="task-list hidden"></ul>
     <label style="display:block;margin-top:0.5rem;"><input type="checkbox" id="stretchToggle"> Show Stretch Tasks</label>
     <ul id="stretchTaskList" class="task-list hidden"></ul>
     <label style="display:block;margin-top:0.5rem;"><input type="checkbox" id="bigToggle"> Show Big Tasks</label>
@@ -58,6 +60,7 @@ let todayList=[], todayTasks=[];
 let overdueTasks=[], dueTasks=[];
 let nextId=1;
 let workDataStore={}, workTasks=[];
+let diyDataStore={}, diyTasks=[];
 function formatISO(date){const d=new Date(date);const y=d.getFullYear();const m=String(d.getMonth()+1).padStart(2,'0');const day=String(d.getDate()).padStart(2,'0');return `${y}-${m}-${day}`;}
 function formatUK(date){const d=new Date(date);if(isNaN(d)) return date||'';return d.toLocaleDateString('en-GB',{day:'2-digit',month:'long',year:'2-digit'});}
 function startOfWeek(date){const d=new Date(date);const day=d.getDay();const diff=(day===0?-6:1-day);d.setDate(d.getDate()+diff);d.setHours(0,0,0,0);return d;}
@@ -75,6 +78,11 @@ async function loadData(){
       workDataStore=await resW.json();
       workTasks=workDataStore.workTasks||[];
     }
+    const resD=await fetch('/api/diy-data');
+    if(resD.ok){
+      diyDataStore=await resD.json();
+      diyTasks=diyDataStore.diyTasks||[];
+    }
   }catch(e){console.error('Failed to load data',e);}
 }
 async function saveData(){const data={projects,weeklyTasks,oneOffTasks,recurringTasks,stretchTasks,bigTasks,deletedTasks,shoppingList,longTermList,generalList,todayList,nextId};try{await fetch('/api/index-data',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}catch(e){console.error('Failed to save data',e);}}
@@ -83,6 +91,12 @@ async function saveWorkData(){
   try{
     await fetch('/api/work-data',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(workDataStore)});
   }catch(e){console.error('Failed to save work data',e);}
+}
+async function saveDiyData(){
+  diyDataStore.diyTasks = diyTasks;
+  try{
+    await fetch('/api/diy-data',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(diyDataStore)});
+  }catch(e){console.error('Failed to save diy data',e);}
 }
 function weeklyDueSoon(task){const today=new Date();for(let i=0;i<7;i++){const d=new Date(today);d.setDate(today.getDate()+i);const name=['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][d.getDay()];if(task.days.includes(name))return true;}return false;}
 function weeklyMissed(task){
@@ -204,6 +218,7 @@ function renderSide(){
     due.appendChild(li);
   });
   if(document.getElementById('workToggle').checked) renderWorkTasks();
+  if(document.getElementById('diyToggle').checked) renderDiyTasks();
   if(document.getElementById('stretchToggle').checked) renderStretchTasks();
   if(document.getElementById('bigToggle').checked) renderBigTasks();
 }
@@ -216,6 +231,19 @@ function renderWorkTasks(){
     const b=document.createElement('button');
     b.textContent='Add';
     b.onclick=()=>addWorkToToday(t.id);
+    li.appendChild(b);
+    ul.appendChild(li);
+  });
+}
+function renderDiyTasks(){
+  const ul=document.getElementById('diyTaskList');
+  ul.innerHTML='';
+  diyTasks.filter(t=>t.status==='open').forEach(t=>{
+    const li=document.createElement('li');
+    li.textContent=`${t.name} (${t.project})`;
+    const b=document.createElement('button');
+    b.textContent='Add';
+    b.onclick=()=>addDiyToToday(t.id);
     li.appendChild(b);
     ul.appendChild(li);
   });
@@ -246,7 +274,43 @@ function renderBigTasks(){
     ul.appendChild(li);
   });
 }
-function renderToday(){const ul=document.getElementById('todayList');ul.innerHTML='';todayTasks.forEach((t,i)=>{const li=document.createElement('li');li.className='today-item';li.draggable=true;li.dataset.index=i;li.textContent=`${t.item.name} (${t.item.project})`;const btnR=document.createElement('button');btnR.textContent='Remove';btnR.onclick=()=>removeToday(i);const btnC=document.createElement('button');btnC.textContent='Complete';btnC.onclick=()=>completeToday(i);li.appendChild(btnR);li.appendChild(btnC);ul.appendChild(li);});}
+function updateToggles(){
+  const wt=document.getElementById('workToggle');
+  const dt=document.getElementById('diyToggle');
+  const hasWork=todayTasks.some(t=>t.type==='work');
+  const hasDiy=todayTasks.some(t=>t.type==='diy');
+  wt.disabled=hasWork;
+  dt.disabled=hasDiy;
+  document.getElementById('workTaskList').classList.toggle('hidden',!wt.checked);
+  document.getElementById('diyTaskList').classList.toggle('hidden',!dt.checked);
+  if(hasWork) wt.checked=true;
+  if(hasDiy) dt.checked=true;
+}
+function renderToday(){
+  const ul=document.getElementById('todayList');
+  ul.innerHTML='';
+  todayTasks.forEach((t,i)=>{
+    const li=document.createElement('li');
+    li.className='today-item';
+    li.draggable=true;
+    li.dataset.index=i;
+    const text=document.createElement('span');
+    text.textContent=`${t.item.name} (${t.item.project})`;
+    const btnBox=document.createElement('span');
+    const btnR=document.createElement('button');
+    btnR.textContent='Remove';
+    btnR.onclick=()=>removeToday(i);
+    const btnC=document.createElement('button');
+    btnC.textContent='Complete';
+    btnC.onclick=()=>completeToday(i);
+    btnBox.appendChild(btnR);
+    btnBox.appendChild(btnC);
+    li.appendChild(text);
+    li.appendChild(btnBox);
+    ul.appendChild(li);
+  });
+  updateToggles();
+}
 function selectTask(t,idx,list){
   if(list==='overdue')overdueTasks.splice(idx,1);else dueTasks.splice(idx,1);
   todayTasks.push(t);
@@ -254,6 +318,7 @@ function selectTask(t,idx,list){
   saveData();
   renderSide();
   renderToday();
+  updateToggles();
 }
 function addWorkToToday(id){
   const task=workTasks.find(t=>t.id===id);
@@ -262,6 +327,16 @@ function addWorkToToday(id){
   todayList.push({type:'work',id});
   saveData();
   renderToday();
+  updateToggles();
+}
+function addDiyToToday(id){
+  const task=diyTasks.find(t=>t.id===id);
+  if(!task) return;
+  todayTasks.push({category:'diy',type:'diy',item:task});
+  todayList.push({type:'diy',id});
+  saveData();
+  renderToday();
+  updateToggles();
 }
 function addStretchToToday(id){
   const task=stretchTasks.find(t=>t.id===id);
@@ -287,6 +362,7 @@ function removeToday(idx){
   saveData();
   renderSide();
   renderToday();
+  updateToggles();
 }
 function clearToday(){
   todayTasks.forEach(t=>{
@@ -298,6 +374,7 @@ function clearToday(){
   saveData();
   renderSide();
   renderToday();
+  updateToggles();
 }
 function computeNextDue(task,actionDate){const base=(task.from==='today')?new Date(actionDate):new Date(task.dueDate);let d=new Date(base);if(task.frequency==='daily')d.setDate(d.getDate()+task.interval);if(task.frequency==='weekly')d.setDate(d.getDate()+7*task.interval);if(task.frequency==='monthly')d.setMonth(d.getMonth()+task.interval);if(task.frequency==='yearly')d.setFullYear(d.getFullYear()+task.interval);return formatISO(d);}
 function completeToday(idx){
@@ -324,7 +401,9 @@ function completeToday(idx){
       t.item.status='closed';
     }
     saveWorkData();
-  }
+  }else if(t.type==='diy'){
+    t.item.status='closed';
+    saveDiyData();
   }else if(t.type==='stretch'){
     t.item.completedDates.push(formatISO(now));
   }else if(t.type==='big'){
@@ -343,6 +422,12 @@ document.getElementById('todayList').addEventListener('dragstart',e=>{if(e.targe
 document.getElementById('workToggle').addEventListener('change',e=>{
   document.getElementById('workTaskList').classList.toggle('hidden',!e.target.checked);
   if(e.target.checked) renderWorkTasks();
+  updateToggles();
+});
+document.getElementById('diyToggle').addEventListener('change',e=>{
+  document.getElementById('diyTaskList').classList.toggle('hidden',!e.target.checked);
+  if(e.target.checked) renderDiyTasks();
+  updateToggles();
 });
 document.getElementById('stretchToggle').addEventListener('change',e=>{
   document.getElementById('stretchTaskList').classList.toggle('hidden',!e.target.checked);

--- a/today.html
+++ b/today.html
@@ -41,6 +41,10 @@ header {
     <ul id="dueList" class="task-list"></ul>
     <label style="display:block;margin-top:0.5rem;"><input type="checkbox" id="workToggle"> Show Work Tasks</label>
     <ul id="workTaskList" class="task-list hidden"></ul>
+    <label style="display:block;margin-top:0.5rem;"><input type="checkbox" id="stretchToggle"> Show Stretch Tasks</label>
+    <ul id="stretchTaskList" class="task-list hidden"></ul>
+    <label style="display:block;margin-top:0.5rem;"><input type="checkbox" id="bigToggle"> Show Big Tasks</label>
+    <ul id="bigTaskList" class="task-list hidden"></ul>
   </div>
   <div id="main">
     <h2>Today</h2>
@@ -49,7 +53,7 @@ header {
   </div>
 </div>
 <script>
-let projects=[], weeklyTasks=[], oneOffTasks=[], recurringTasks=[], deletedTasks=[], shoppingList=[], longTermList=[], generalList=[];
+let projects=[], weeklyTasks=[], oneOffTasks=[], recurringTasks=[], stretchTasks=[], bigTasks=[], deletedTasks=[], shoppingList=[], longTermList=[], generalList=[];
 let todayList=[], todayTasks=[];
 let overdueTasks=[], dueTasks=[];
 let nextId=1;
@@ -63,7 +67,7 @@ async function loadData(){
     if(res.ok){
       const obj=await res.json();
       projects=obj.projects||[];weeklyTasks=obj.weeklyTasks||[];oneOffTasks=obj.oneOffTasks||[];recurringTasks=obj.recurringTasks||[];
-      deletedTasks=obj.deletedTasks||[];shoppingList=obj.shoppingList||[];longTermList=obj.longTermList||[];
+      stretchTasks=obj.stretchTasks||[];bigTasks=obj.bigTasks||[];deletedTasks=obj.deletedTasks||[];shoppingList=obj.shoppingList||[];longTermList=obj.longTermList||[];
       generalList=obj.generalList||[];todayList=obj.todayList||[];nextId=obj.nextId||1;
     }
     const resW=await fetch('/api/work-data');
@@ -73,7 +77,7 @@ async function loadData(){
     }
   }catch(e){console.error('Failed to load data',e);}
 }
-async function saveData(){const data={projects,weeklyTasks,oneOffTasks,recurringTasks,deletedTasks,shoppingList,longTermList,generalList,todayList,nextId};try{await fetch('/api/index-data',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}catch(e){console.error('Failed to save data',e);}}
+async function saveData(){const data={projects,weeklyTasks,oneOffTasks,recurringTasks,stretchTasks,bigTasks,deletedTasks,shoppingList,longTermList,generalList,todayList,nextId};try{await fetch('/api/index-data',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}catch(e){console.error('Failed to save data',e);}}
 async function saveWorkData(){
   workDataStore.workTasks = workTasks;
   try{
@@ -137,11 +141,19 @@ function rebuildToday(){
     else if(r.type==='recurring') arr=recurringTasks;
     else if(r.type==='weekly') arr=weeklyTasks;
     else if(r.type==='work') arr=workTasks;
+    else if(r.type==='stretch') arr=stretchTasks;
+    else if(r.type==='big') arr=bigTasks;
     else return;
     const task=arr.find(t=>t.id===r.id);
     if(!task) return;
     if(r.type==='work'){
       todayTasks.push({category:'work',type:'work',item:task});
+      return;
+    } else if(r.type==='stretch'){
+      todayTasks.push({category:'stretch',type:'stretch',item:task});
+      return;
+    } else if(r.type==='big'){
+      todayTasks.push({category:'big',type:'big',item:task});
       return;
     }
     let i=overdueTasks.findIndex(o=>o.type===r.type&&o.item.id===r.id);
@@ -192,6 +204,8 @@ function renderSide(){
     due.appendChild(li);
   });
   if(document.getElementById('workToggle').checked) renderWorkTasks();
+  if(document.getElementById('stretchToggle').checked) renderStretchTasks();
+  if(document.getElementById('bigToggle').checked) renderBigTasks();
 }
 function renderWorkTasks(){
   const ul=document.getElementById('workTaskList');
@@ -202,6 +216,32 @@ function renderWorkTasks(){
     const b=document.createElement('button');
     b.textContent='Add';
     b.onclick=()=>addWorkToToday(t.id);
+    li.appendChild(b);
+    ul.appendChild(li);
+  });
+}
+function renderStretchTasks(){
+  const ul=document.getElementById('stretchTaskList');
+  ul.innerHTML='';
+  stretchTasks.filter(t=>t.status==='open').forEach(t=>{
+    const li=document.createElement('li');
+    li.textContent=`${t.name} (${t.project})`;
+    const b=document.createElement('button');
+    b.textContent='Add';
+    b.onclick=()=>addStretchToToday(t.id);
+    li.appendChild(b);
+    ul.appendChild(li);
+  });
+}
+function renderBigTasks(){
+  const ul=document.getElementById('bigTaskList');
+  ul.innerHTML='';
+  bigTasks.filter(t=>t.status==='open').forEach(t=>{
+    const li=document.createElement('li');
+    li.textContent=`${t.name} (${t.project})`;
+    const b=document.createElement('button');
+    b.textContent='Add';
+    b.onclick=()=>addBigToToday(t.id);
     li.appendChild(b);
     ul.appendChild(li);
   });
@@ -220,6 +260,22 @@ function addWorkToToday(id){
   if(!task) return;
   todayTasks.push({category:'work',type:'work',item:task});
   todayList.push({type:'work',id});
+  saveData();
+  renderToday();
+}
+function addStretchToToday(id){
+  const task=stretchTasks.find(t=>t.id===id);
+  if(!task) return;
+  todayTasks.push({category:'stretch',type:'stretch',item:task});
+  todayList.push({type:'stretch',id});
+  saveData();
+  renderToday();
+}
+function addBigToToday(id){
+  const task=bigTasks.find(t=>t.id===id);
+  if(!task) return;
+  todayTasks.push({category:'big',type:'big',item:task});
+  todayList.push({type:'big',id});
   saveData();
   renderToday();
 }
@@ -269,6 +325,13 @@ function completeToday(idx){
     }
     saveWorkData();
   }
+  }else if(t.type==='stretch'){
+    t.item.completedDates.push(formatISO(now));
+  }else if(t.type==='big'){
+    t.item.completedDates.push(formatISO(now));
+    t.item.status='closed';
+    t.item.closedDate=formatISO(now);
+  }
   if(t.category==='overdue'){/* do nothing */}
   else if(t.category==='due'){/* keep order */}
   saveData();
@@ -280,6 +343,14 @@ document.getElementById('todayList').addEventListener('dragstart',e=>{if(e.targe
 document.getElementById('workToggle').addEventListener('change',e=>{
   document.getElementById('workTaskList').classList.toggle('hidden',!e.target.checked);
   if(e.target.checked) renderWorkTasks();
+});
+document.getElementById('stretchToggle').addEventListener('change',e=>{
+  document.getElementById('stretchTaskList').classList.toggle('hidden',!e.target.checked);
+  if(e.target.checked) renderStretchTasks();
+});
+document.getElementById('bigToggle').addEventListener('change',e=>{
+  document.getElementById('bigTaskList').classList.toggle('hidden',!e.target.checked);
+  if(e.target.checked) renderBigTasks();
 });
 async function init(){await loadData();categorize();rebuildToday();renderSide();renderToday();}
 init();

--- a/work.html
+++ b/work.html
@@ -208,6 +208,7 @@ let maxSubDepth = 7;
 let calendarEvents = [];
 let calendarNextId = 1;
 let calendar;
+let calendarDraggable = null;
 let meetings = [];
 let meetingNextId = 1;
 let currentMeeting = null;
@@ -525,7 +526,10 @@ function renderCalendarTasks(){
     div.dataset.title=t.name;
     cont.appendChild(div);
   });
-  new FullCalendar.Draggable(cont,{itemSelector:'.fc-task',eventData:el=>({title:el.dataset.title,taskId:el.dataset.id})});
+  if(calendarDraggable){
+    calendarDraggable.destroy();
+  }
+  calendarDraggable=new FullCalendar.Draggable(cont,{itemSelector:'.fc-task',eventData:el=>({title:el.dataset.title,taskId:el.dataset.id})});
 }
 
 function initCalendar(){

--- a/work.html
+++ b/work.html
@@ -503,11 +503,12 @@ function renderTasks(){
     row.ondrop=ev=>dropOnTask(ev,t.id);
     row.innerHTML=`<div>${t.name}</div><div>${t.project}</div><div>${t.dueDate||''}</div><div>${t.importance}</div><div>${t.urgency}</div>`;
     const ctrl=document.createElement('div'); ctrl.className='controls';
+    const info=document.createElement('button'); info.textContent='Info'; info.onclick=()=>showInfo(t);
     const comp=document.createElement('button'); comp.textContent='Complete'; comp.onclick=()=>completeTask(t.id);
     const edit=document.createElement('button'); edit.textContent='Edit'; edit.onclick=()=>editTask(t.id);
     const sub=document.createElement('button'); sub.textContent='Add Sub'; sub.onclick=()=>addSubtask(t.id);
     const del=document.createElement('button'); del.textContent='Delete'; del.onclick=()=>deleteTask(t.id);
-    ctrl.appendChild(comp); ctrl.appendChild(edit); ctrl.appendChild(sub); ctrl.appendChild(del);
+    ctrl.appendChild(info); ctrl.appendChild(comp); ctrl.appendChild(edit); ctrl.appendChild(sub); ctrl.appendChild(del);
     row.appendChild(ctrl);
     list.appendChild(row);
   });
@@ -561,6 +562,9 @@ function deleteCalendarEvents(taskId){
   if(!calendar) return;
   calendar.getEvents().forEach(ev=>{if(ev.extendedProps.taskId===taskId) ev.remove();});
   saveCalendar();
+}
+function showInfo(t){
+  alert(`Name: ${t.name}\nProject: ${t.project}\nDue: ${t.dueDate||''}\nImportance: ${t.importance}\nUrgency: ${t.urgency}\nNotes: ${t.notes||''}`);
 }
 function meetingStatus(date){
   const today=new Date().toISOString().slice(0,10);


### PR DESCRIPTION
## Summary
- bold self care tasks and tweak meta size
- add Stretch Tasks and Big Tasks sections
- persist new task arrays
- expose stretch/big lists and toggles on Today page

## Testing
- `npm test` *(fails: Missing script)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68873ca13e8c832f82cdfcc7aab4fc11