### PR TITLE
Show origin and priority of Today tasks

### DIFF
--- a/diy.html
+++ b/diy.html
@@ -17,6 +17,8 @@ section{padding:1rem;border-bottom:10px solid pink;}
 .form-grid input,.form-grid select,.form-grid textarea{width:100%;font-size:1rem;padding:0.4rem;}
 .hidden{display:none !important;}
 .task-row{display:grid;grid-template-columns:2fr 1fr 1fr 1fr 0.5fr;gap:0.25rem;align-items:center;border:1px solid #ccc;padding:0.25rem;margin-top:0.25rem;}
+#taskList{max-height:400px;overflow-y:auto;overflow-x:hidden;width:calc(100% - 1rem);padding-right:1rem;}
+.task-row div{word-break:break-word;}
 .controls button{margin-left:0.25rem;font-size:0.7rem;}
 .filter-grid{display:flex;gap:0.5rem;flex-wrap:wrap;margin-bottom:0.5rem;}
 .calendar-container{display:flex;gap:1rem;flex-wrap:wrap;}
@@ -65,6 +67,27 @@ section{padding:1rem;border-bottom:10px solid pink;}
 
 
 <section>
+  <div class="toggle section-header" onclick="toggle('bigTaskSection')">Big Tasks</div>
+  <div id="bigTaskSection" class="hidden">
+    <div id="bigTaskList"></div>
+    <div class="toggle add-toggle" onclick="toggle('addBigTaskForm')">Add Big Task</div>
+    <div id="addBigTaskForm" class="hidden form-grid">
+      <label>Name<input type="text" id="bigTaskName"></label>
+      <label>Project<select id="bigTaskProject"></select></label>
+      <label>Type<select id="bigTaskType"></select></label>
+      <label>Priority<input type="number" id="bigTaskPriority" min="1"></label>
+      <label>Due Date<input type="date" id="bigTaskDue"></label>
+      <label><input type="checkbox" id="bigTaskUrgent"> Urgent</label>
+      <label>Info<textarea id="bigTaskInfo"></textarea></label>
+      <div style="grid-column:1/-1;text-align:center;">
+        <button onclick="addBigTask()">Submit</button>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<section>
   <div class="toggle section-header" onclick="toggle('calendarSection')">Calendar</div>
   <div id="calendarSection" class="hidden">
     <div class="calendar-container">
@@ -90,6 +113,25 @@ section{padding:1rem;border-bottom:10px solid pink;}
   </div>
 </section>
 
+<section>
+  <div class="toggle section-header" onclick="toggle('diyShopSection')">DIY Shopping List</div>
+  <div id="diyShopSection" class="hidden">
+    <div id="diyShoppingList"></div>
+    <div class="toggle add-toggle" onclick="toggle('addDiyShop')">Add Item</div>
+    <div id="addDiyShop" class="hidden form-grid">
+      <label>Name<input type="text" id="diyShopName"></label>
+      <label>Project<select id="diyShopProject"></select></label>
+      <label>Type<select id="diyShopType"></select></label>
+      <label>Cost<input type="number" id="diyShopCost" step="0.01"></label>
+      <label>Target Month<input type="month" id="diyShopMonth"></label>
+      <input type="hidden" id="diyShopTask">
+      <div style="grid-column:1/-1;text-align:center;">
+        <button onclick="addDiyShopItem()">Submit</button>
+      </div>
+    </div>
+  </div>
+</section>
+
 <div id="taskModal" class="modal hidden">
   <div class="modal-content">
     <label>Name<input id="taskModalName"></label>
@@ -110,6 +152,8 @@ let store={};
 let diyProjects=[];
 let diyTypes=[];
 let diyTasks=[];
+let diyBigTasks=[];
+let diyShoppingList=[];
 let diyNextId=1;
 let maxSubDepth=7;
 let calendarEvents=[];
@@ -130,6 +174,8 @@ async function loadData(){
       diyProjects=store.diyProjects||[];
       diyTypes=store.diyTypes||[];
       diyTasks=store.diyTasks||[];
+      diyBigTasks=store.diyBigTasks||[];
+      diyShoppingList=store.diyShoppingList||[];
       diyNextId=store.diyNextId||1;
       maxSubDepth=store.maxSubDepth||7;
       calendarEvents=store.calendarEvents||[];
@@ -138,6 +184,8 @@ async function loadData(){
     renderProjects();
     renderTypes();
     renderTasks();
+    renderBigTasks();
+    renderDiyShopping();
     renderCalendarTasks();
     initCalendar();
   }catch(e){console.error('load fail',e);}
@@ -147,6 +195,8 @@ async function saveData(){
   store.diyProjects=diyProjects;
   store.diyTypes=diyTypes;
   store.diyTasks=diyTasks;
+  store.diyBigTasks=diyBigTasks;
+  store.diyShoppingList=diyShoppingList;
   store.diyNextId=diyNextId;
   store.maxSubDepth=maxSubDepth;
   store.calendarEvents=calendarEvents;
@@ -170,11 +220,15 @@ function renderProjects(){
   const ul=document.getElementById('diyProjectList');
   const sel=document.getElementById('taskProject');
   const sel2=document.getElementById('taskModalProject');
+  const bigSel=document.getElementById('bigTaskProject');
+  const shopSel=document.getElementById('diyShopProject');
   const filt=document.getElementById('filterProject');
-  ul.innerHTML=''; sel.innerHTML=''; sel2.innerHTML=''; filt.innerHTML='<option value="all">All</option>';
+  ul.innerHTML=''; sel.innerHTML=''; sel2.innerHTML=''; if(bigSel) bigSel.innerHTML=''; if(shopSel) shopSel.innerHTML=''; filt.innerHTML='<option value="all">All</option>';
   diyProjects.forEach(p=>{
     const li=document.createElement('li'); li.style.color=p.color; li.textContent=p.name; ul.appendChild(li);
     const opt=document.createElement('option'); opt.value=p.name; opt.textContent=p.name; sel.appendChild(opt); sel2.appendChild(opt.cloneNode(true));
+    if(bigSel) bigSel.appendChild(opt.cloneNode(true));
+    if(shopSel) shopSel.appendChild(opt.cloneNode(true));
     const opt2=opt.cloneNode(true); filt.appendChild(opt2);
   });
 }
@@ -192,10 +246,16 @@ function renderTypes(){
   const ul=document.getElementById('typeList');
   const sel=document.getElementById('taskType');
   const sel2=document.getElementById('taskModalType');
+  const bigSel=document.getElementById('bigTaskType');
+  const shopSel=document.getElementById('diyShopType');
   ul.innerHTML=''; sel.innerHTML=''; sel2.innerHTML='';
+  if(bigSel) bigSel.innerHTML='';
+  if(shopSel) shopSel.innerHTML='';
   diyTypes.forEach(t=>{
     const li=document.createElement('li'); li.textContent=t; ul.appendChild(li);
     const opt=document.createElement('option'); opt.value=t; opt.textContent=t; sel.appendChild(opt); sel2.appendChild(opt.cloneNode(true));
+    if(bigSel) bigSel.appendChild(opt.cloneNode(true));
+    if(shopSel) shopSel.appendChild(opt.cloneNode(true));
   });
 }
 
@@ -326,8 +386,9 @@ function renderTasks(){
     const comp=document.createElement('button'); comp.textContent='Complete'; comp.onclick=()=>completeTask(t.id);
     const edit=document.createElement('button'); edit.textContent='Edit'; edit.onclick=()=>editTask(t.id);
     const sub=document.createElement('button'); sub.textContent='Add Sub'; sub.onclick=()=>addSubtask(t.id);
+    const item=document.createElement('button'); item.textContent='Add Item'; item.onclick=()=>openShoppingForTask(t.id);
     const del=document.createElement('button'); del.textContent='Delete'; del.onclick=()=>deleteTask(t.id);
-    ctrl.appendChild(infoBtn); ctrl.appendChild(comp); ctrl.appendChild(edit); ctrl.appendChild(sub); ctrl.appendChild(del);
+    ctrl.appendChild(infoBtn); ctrl.appendChild(comp); ctrl.appendChild(edit); ctrl.appendChild(sub); ctrl.appendChild(item); ctrl.appendChild(del);
     row.appendChild(ctrl);
     list.appendChild(row);
   });
@@ -337,13 +398,14 @@ function renderTasks(){
 function renderCalendarTasks(){
   const cont=document.getElementById('calendarTaskList');
   cont.innerHTML='';
-  forEachTask(t=>{
+  forEachTask((t,depth)=>{
     if(t.status!=='open') return;
     const div=document.createElement('div');
     div.className='fc-task';
     div.textContent=t.name;
     div.dataset.id=t.id;
     div.dataset.title=t.name;
+    div.style.marginLeft=depth+'rem';
     cont.appendChild(div);
   });
   if(calendarDraggable){
@@ -361,6 +423,134 @@ function saveCalendar(){calendarEvents=calendar.getEvents().map(ev=>({id:ev.id,t
 function deleteCalendarEvents(taskId){if(!calendar) return; calendar.getEvents().forEach(ev=>{if(ev.extendedProps.taskId===taskId) ev.remove();}); saveCalendar();}
 function showInfo(t){
   alert(`Name: ${t.name}\nProject: ${t.project}\nType: ${t.type}\nDue: ${t.dueDate||''}\nUrgent: ${t.urgent?'Yes':'No'}\nInfo: ${t.info||''}`);
+}
+
+function addBigTask(){
+  const name=document.getElementById('bigTaskName').value.trim();
+  if(!name) return;
+  const task={id:String(diyNextId).padStart(8,'0'),name,project:document.getElementById('bigTaskProject').value,type:document.getElementById('bigTaskType').value,priority:parseInt(document.getElementById('bigTaskPriority').value)||diyBigTasks.length+1,dueDate:document.getElementById('bigTaskDue').value,urgent:document.getElementById('bigTaskUrgent').checked,info:document.getElementById('bigTaskInfo').value,status:'open'};
+  diyNextId++; diyBigTasks.push(task); updateBigPriorities();
+  document.getElementById('bigTaskName').value='';
+  document.getElementById('bigTaskPriority').value='';
+  document.getElementById('bigTaskDue').value='';
+  document.getElementById('bigTaskUrgent').checked=false;
+  document.getElementById('bigTaskInfo').value='';
+  saveData();
+  renderBigTasks();
+}
+
+function renderBigTasks(){
+  const div=document.getElementById('bigTaskList');
+  div.innerHTML='';
+  ensureBigTaskPriorities();
+  const open=diyBigTasks.filter(t=>t.status==='open').sort((a,b)=>a.priority-b.priority);
+  if(open.length===0){div.textContent='No big tasks';return;}
+  open.forEach(t=>{
+    const row=document.createElement('div'); row.className='task-row';
+    row.innerHTML=`<div>${t.name}</div><div>${t.project}</div><div>${t.type}</div><div>${t.dueDate||''}</div><div>${t.urgent?'Y':'N'}</div><div>${t.priority}</div>`;
+    const ctrl=document.createElement('div'); ctrl.className='controls';
+    const info=document.createElement('button'); info.textContent='Info'; info.onclick=()=>showInfo(t);
+    const comp=document.createElement('button'); comp.textContent='Complete'; comp.onclick=()=>completeBigTask(t.id);
+    const add=document.createElement('button'); add.textContent='Add Item'; add.onclick=()=>openShoppingForTask(t.id);
+    const up=document.createElement('button'); up.textContent='Up'; up.onclick=()=>moveBigTaskUp(t.id);
+    const down=document.createElement('button'); down.textContent='Down'; down.onclick=()=>moveBigTaskDown(t.id);
+    const del=document.createElement('button'); del.textContent='Delete'; del.onclick=()=>deleteBigTask(t.id);
+    ctrl.appendChild(info); ctrl.appendChild(add); ctrl.appendChild(comp); ctrl.appendChild(up); ctrl.appendChild(down); ctrl.appendChild(del);
+    row.appendChild(ctrl); div.appendChild(row);
+  });
+}
+
+function completeBigTask(id){
+  const t=diyBigTasks.find(x=>x.id===id); if(!t) return; t.status='closed'; saveData(); renderBigTasks();
+}
+
+function deleteBigTask(id){
+  const idx=diyBigTasks.findIndex(x=>x.id===id); if(idx===-1) return; diyBigTasks.splice(idx,1); saveData(); renderBigTasks();
+}
+
+function ensureBigTaskPriorities(){
+  diyBigTasks.forEach((t,i)=>{ if(!t.priority) t.priority=i+1; });
+}
+
+function updateBigPriorities(){
+  diyBigTasks.forEach((t,i)=>{ t.priority=i+1; });
+}
+
+function moveBigTaskUp(id){
+  const idx=diyBigTasks.findIndex(t=>t.id===id);
+  if(idx>0){
+    [diyBigTasks[idx-1],diyBigTasks[idx]]=[diyBigTasks[idx],diyBigTasks[idx-1]];
+    updateBigPriorities();
+    saveData();
+    renderBigTasks();
+  }
+}
+
+function moveBigTaskDown(id){
+  const idx=diyBigTasks.findIndex(t=>t.id===id);
+  if(idx!==-1 && idx<diyBigTasks.length-1){
+    [diyBigTasks[idx],diyBigTasks[idx+1]]=[diyBigTasks[idx+1],diyBigTasks[idx]];
+    updateBigPriorities();
+    saveData();
+    renderBigTasks();
+  }
+}
+
+function getAnyTask(id){
+  let info=getTaskInfo(id);
+  if(info) return info.task;
+  return diyBigTasks.find(t=>t.id===id) || null;
+}
+
+function openShoppingForTask(id){
+  const task=getAnyTask(id);
+  if(!task) return;
+  document.getElementById('diyShopTask').value=id;
+  document.getElementById('diyShopProject').value=task.project;
+  document.getElementById('diyShopType').value=task.type;
+  document.getElementById('diyShopSection').classList.remove('hidden');
+  document.getElementById('addDiyShop').classList.remove('hidden');
+  document.getElementById('diyShopName').focus();
+}
+
+function addDiyShopItem(){
+  const name=document.getElementById('diyShopName').value.trim();
+  if(!name) return;
+  const item={id:String(diyNextId).padStart(8,'0'),name,project:document.getElementById('diyShopProject').value,type:document.getElementById('diyShopType').value,cost:document.getElementById('diyShopCost').value,month:document.getElementById('diyShopMonth').value,taskId:document.getElementById('diyShopTask').value||null,bought:false};
+  diyNextId++; diyShoppingList.push(item);
+  document.getElementById('diyShopName').value='';
+  document.getElementById('diyShopCost').value='';
+  document.getElementById('diyShopMonth').value='';
+  document.getElementById('diyShopTask').value='';
+  saveData();
+  renderDiyShopping();
+}
+
+function renderDiyShopping(){
+  const div=document.getElementById('diyShoppingList');
+  div.innerHTML='';
+  const open=diyShoppingList.filter(i=>!i.bought);
+  if(open.length===0){div.textContent='No items';return;}
+  const table=document.createElement('table'); table.className='task-table';
+  const head=document.createElement('tr'); head.innerHTML='<th>Item</th><th>Task</th><th>Project</th><th>Type</th><th>Cost</th><th>Month</th><th></th>'; table.appendChild(head);
+  open.forEach(it=>{
+    const tr=document.createElement('tr'); const proj=diyProjects.find(p=>p.name===it.project); const color=proj?proj.color:'#000';
+    const task=getAnyTask(it.taskId)||{};
+    tr.innerHTML=`<td>${it.name}</td><td>${task.name||''}</td><td style="color:${color}">${it.project}</td><td>${it.type}</td><td>${it.cost||''}</td><td>${it.month||''}</td>`;
+    const td=document.createElement('td');
+    const b=document.createElement('button'); b.textContent='Bought'; b.onclick=()=>toggleBoughtDiyShop(it.id);
+    const del=document.createElement('button'); del.textContent='Delete'; del.onclick=()=>deleteDiyShopItem(it.id);
+    td.appendChild(b); td.appendChild(del); tr.appendChild(td); table.appendChild(tr);
+  });
+  div.appendChild(table);
+}
+
+function toggleBoughtDiyShop(id){
+  const it=diyShoppingList.find(i=>i.id===id); if(!it) return; it.bought=true; saveData(); renderDiyShopping();
+}
+
+function deleteDiyShopItem(id){
+  const idx=diyShoppingList.findIndex(i=>i.id===id); if(idx===-1) return; diyShoppingList.splice(idx,1); saveData(); renderDiyShopping();
 }
 
 loadData();

--- a/diyData.json
+++ b/diyData.json
@@ -2,6 +2,8 @@
   "diyProjects": [],
   "diyTypes": [],
   "diyTasks": [],
+  "diyBigTasks": [],
+  "diyShoppingList": [],
   "diyNextId": 1,
   "maxSubDepth": 7,
   "calendarEvents": [],

--- a/server.js
+++ b/server.js
@@ -46,6 +46,8 @@ let diyData = {
   diyProjects: [],
   diyTypes: [],
   diyTasks: [],
+  diyBigTasks: [],
+  diyShoppingList: [],
   diyNextId: 1,
   maxSubDepth: 7,
   calendarEvents: [],

--- a/shopping.html
+++ b/shopping.html
@@ -69,6 +69,25 @@ section {
 </section>
 
 <section>
+  <div class="toggle section-header" onclick="toggle('diyShopSection')">DIY Shopping List</div>
+  <div id="diyShopSection" class="hidden">
+    <div id="diyShopList"></div>
+    <div class="toggle add-toggle" onclick="toggle('addDiyShop')">Add Item</div>
+    <div id="addDiyShop" class="hidden subtoggle form-grid">
+      <label>Name<input type="text" id="diyShopName"></label>
+      <label>Project<select id="diyShopProject"></select></label>
+      <label>Type<select id="diyShopType"></select></label>
+      <label>Cost<input type="number" id="diyShopCost" step="0.01"></label>
+      <label>Month<input type="month" id="diyShopMonth"></label>
+      <input type="hidden" id="diyShopTask">
+      <div style="grid-column:1/-1;text-align:center;">
+        <button onclick="addDiyShopItem()">Submit</button>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
   <div class="toggle section-header" onclick="toggle('longTermSection')">Long Term Buying</div>
   <div id="longTermSection" class="hidden">
     <div id="longTermList"></div>
@@ -104,6 +123,10 @@ let projects = [];
 let shoppingList = [];
 let longTermList = [];
 let generalList = [];
+let diyShoppingList = [];
+let diyDataStore = {};
+let diyTasks = [];
+let diyBigTasks = [];
 let weeklyTasks = [];
 let oneOffTasks = [];
 let recurringTasks = [];
@@ -124,6 +147,13 @@ async function saveData() {
   }
 }
 
+async function saveDiyData(){
+  diyDataStore.diyShoppingList = diyShoppingList;
+  try{
+    await fetch('/api/diy-data',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(diyDataStore)});
+  }catch(e){console.error('Failed to save diy data',e);}
+}
+
 async function loadData() {
   try {
     const res = await fetch('/api/index-data');
@@ -139,6 +169,13 @@ async function loadData() {
     generalList = obj.generalList || [];
     todayList = obj.todayList || [];
     nextId = obj.nextId || 1;
+    const resD = await fetch('/api/diy-data');
+    if(resD.ok){
+      diyDataStore = await resD.json();
+      diyShoppingList = diyDataStore.diyShoppingList || [];
+      diyTasks = diyDataStore.diyTasks || [];
+      diyBigTasks = diyDataStore.diyBigTasks || [];
+    }
   } catch (e) {
     console.error('Failed to load data', e);
   }
@@ -159,7 +196,8 @@ function showMessage(msg) {
 function renderProjects() {
   const selects = [
     document.getElementById('shoppingProject'),
-    document.getElementById('longTermProject')
+    document.getElementById('longTermProject'),
+    document.getElementById('diyShopProject')
   ];
   selects.forEach(select => {
     if (!select) return;
@@ -377,12 +415,59 @@ function deleteGeneral(id) {
   renderGeneral();
 }
 
+function getTaskName(id){
+  let t=diyTasks.find(x=>x.id===id);
+  if(!t) t=diyBigTasks.find(x=>x.id===id);
+  return t?t.name:'';
+}
+
+function addDiyShopItem(){
+  const name=document.getElementById('diyShopName').value;
+  if(!name) return;
+  const item={id:String(nextId).padStart(8,'0'),name,project:document.getElementById('diyShopProject').value,type:document.getElementById('diyShopType').value,cost:document.getElementById('diyShopCost').value,month:document.getElementById('diyShopMonth').value,taskId:document.getElementById('diyShopTask').value||null,bought:false};
+  nextId++; diyShoppingList.push(item);
+  document.getElementById('diyShopName').value='';
+  document.getElementById('diyShopCost').value='';
+  document.getElementById('diyShopMonth').value='';
+  document.getElementById('diyShopTask').value='';
+  saveDiyData();
+  renderDiyShop();
+}
+
+function renderDiyShop(){
+  const div=document.getElementById('diyShopList');
+  div.innerHTML='';
+  const open=diyShoppingList.filter(i=>!i.bought);
+  if(open.length===0){div.textContent='No items';return;}
+  const table=document.createElement('table'); table.className='task-table';
+  const head=document.createElement('tr'); head.innerHTML='<th>Item</th><th>Task</th><th>Project</th><th>Type</th><th>Cost</th><th>Month</th><th></th>'; table.appendChild(head);
+  open.forEach(it=>{
+    const tr=document.createElement('tr'); const proj=projects.find(p=>p.name===it.project); const color=proj?proj.color:'#000';
+    const task=(diyShoppingList&&diyDataStore&&diyDataStore.diyTasks)?getTaskName(it.taskId):'';
+    tr.innerHTML=`<td>${it.name}</td><td>${task}</td><td style="color:${color}">${it.project}</td><td>${it.type}</td><td>${it.cost||''}</td><td>${it.month||''}</td>`;
+    const td=document.createElement('td');
+    const b=document.createElement('button'); b.textContent='Bought'; b.onclick=()=>toggleBoughtDiyShop(it.id);
+    const del=document.createElement('button'); del.textContent='Delete'; del.onclick=()=>deleteDiyShopItem(it.id);
+    td.appendChild(b); td.appendChild(del); tr.appendChild(td); table.appendChild(tr);
+  });
+  div.appendChild(table);
+}
+
+function toggleBoughtDiyShop(id){
+  const it=diyShoppingList.find(i=>i.id===id); if(!it) return; it.bought=true; saveDiyData(); renderDiyShop();
+}
+
+function deleteDiyShopItem(id){
+  const idx=diyShoppingList.findIndex(i=>i.id===id); if(idx===-1) return; diyShoppingList.splice(idx,1); saveDiyData(); renderDiyShop();
+}
+
 async function init() {
   await loadData();
   renderProjects();
   renderShopping();
   renderLongTerm();
   renderGeneral();
+  renderDiyShop();
 }
 init();
 </script>

--- a/today.html
+++ b/today.html
@@ -17,7 +17,8 @@ header {
 #side { width: 40%; padding: 1rem; border-left: 1px solid #ccc; }
 #main { flex: 1; padding: 1rem; }
 .task-list { list-style: none; padding: 0; }
-.task-list li { margin: 0.25rem 0; padding: 0.25rem; border-bottom: 1px solid #ddd; display:flex; justify-content: space-between; align-items:center; }
+.task-list li { margin: 0.25rem 0; padding: 0.25rem; border-bottom: 1px solid #ddd; display:flex; justify-content: space-between; align-items:center; flex-wrap:wrap; }
+#todayListContainer{max-height:400px;overflow-y:auto;overflow-x:hidden;width:calc(100% - 1rem);padding-right:1rem;}
 .overdue { color: red; }
 .due { color: orange; }
 .due-soon { font-weight: bold; }
@@ -47,11 +48,15 @@ header {
     <ul id="stretchTaskList" class="task-list hidden"></ul>
     <label style="display:block;margin-top:0.5rem;"><input type="checkbox" id="bigToggle"> Show Big Tasks</label>
     <ul id="bigTaskList" class="task-list hidden"></ul>
+    <label style="display:block;margin-top:0.5rem;"><input type="checkbox" id="diyBigToggle"> Show DIY Big Tasks</label>
+    <ul id="diyBigTaskList" class="task-list hidden"></ul>
   </div>
   <div id="main">
     <h2>Today</h2>
     <button onclick="clearToday()">Clear</button>
-    <ul id="todayList" class="task-list"></ul>
+    <div id="todayListContainer">
+      <ul id="todayList" class="task-list"></ul>
+    </div>
   </div>
 </div>
 <script>
@@ -59,8 +64,48 @@ let projects=[], weeklyTasks=[], oneOffTasks=[], recurringTasks=[], stretchTasks
 let todayList=[], todayTasks=[];
 let overdueTasks=[], dueTasks=[];
 let nextId=1;
-let workDataStore={}, workTasks=[];
-let diyDataStore={}, diyTasks=[];
+let workDataStore={}, workTasks=[], workCalendar=[];
+let diyDataStore={}, diyTasks=[], diyBigTasks=[], diyCalendar=[];
+function getWorkTaskInfo(id,list=workTasks,depth=0,parent=null){
+  for(const t of list){
+    if(t.id===id) return {task:t,parent,depth};
+    if(t.subtasks){
+      const r=getWorkTaskInfo(id,t.subtasks,depth+1,t);
+      if(r) return r;
+    }
+  }
+  return null;
+}
+function forEachWorkTask(cb,list=workTasks,depth=0,parent=null){
+  list.forEach(t=>{
+    cb(t,depth,parent);
+    if(t.subtasks) forEachWorkTask(cb,t.subtasks,depth+1,t);
+  });
+}
+function getDiyTaskInfo(id,list=diyTasks,depth=0,parent=null){
+  for(const t of list){
+    if(t.id===id) return {task:t,parent,depth};
+    if(t.subtasks){
+      const r=getDiyTaskInfo(id,t.subtasks,depth+1,t);
+      if(r) return r;
+    }
+  }
+  return null;
+}
+function forEachDiyTask(cb,list=diyTasks,depth=0,parent=null){
+  list.forEach(t=>{
+    cb(t,depth,parent);
+    if(t.subtasks) forEachDiyTask(cb,t.subtasks,depth+1,t);
+  });
+}
+function taskScheduledToday(type,id){
+  const today=formatISO(new Date());
+  let events=[];
+  if(type==='work') events=workCalendar;
+  else if(type==='diy') events=diyCalendar;
+  else return false;
+  return events.some(ev=>ev.taskId===id && ev.start.slice(0,10)===today);
+}
 function formatISO(date){const d=new Date(date);const y=d.getFullYear();const m=String(d.getMonth()+1).padStart(2,'0');const day=String(d.getDate()).padStart(2,'0');return `${y}-${m}-${day}`;}
 function formatUK(date){const d=new Date(date);if(isNaN(d)) return date||'';return d.toLocaleDateString('en-GB',{day:'2-digit',month:'long',year:'2-digit'});}
 function startOfWeek(date){const d=new Date(date);const day=d.getDay();const diff=(day===0?-6:1-day);d.setDate(d.getDate()+diff);d.setHours(0,0,0,0);return d;}
@@ -77,11 +122,14 @@ async function loadData(){
     if(resW.ok){
       workDataStore=await resW.json();
       workTasks=workDataStore.workTasks||[];
+      workCalendar=workDataStore.calendarEvents||[];
     }
     const resD=await fetch('/api/diy-data');
     if(resD.ok){
       diyDataStore=await resD.json();
       diyTasks=diyDataStore.diyTasks||[];
+      diyBigTasks=diyDataStore.diyBigTasks||[];
+      diyCalendar=diyDataStore.calendarEvents||[];
     }
   }catch(e){console.error('Failed to load data',e);}
 }
@@ -94,6 +142,7 @@ async function saveWorkData(){
 }
 async function saveDiyData(){
   diyDataStore.diyTasks = diyTasks;
+  diyDataStore.diyBigTasks = diyBigTasks;
   try{
     await fetch('/api/diy-data',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(diyDataStore)});
   }catch(e){console.error('Failed to save diy data',e);}
@@ -154,20 +203,34 @@ function rebuildToday(){
     if(r.type==='oneoff') arr=oneOffTasks;
     else if(r.type==='recurring') arr=recurringTasks;
     else if(r.type==='weekly') arr=weeklyTasks;
-    else if(r.type==='work') arr=workTasks;
     else if(r.type==='stretch') arr=stretchTasks;
     else if(r.type==='big') arr=bigTasks;
-    else return;
-    const task=arr.find(t=>t.id===r.id);
+    else if(r.type==='diybig') arr=diyBigTasks;
+    let task=null, depth=0;
+    if(r.type==='work'){
+      const info=getWorkTaskInfo(r.id);
+      if(info){ task=info.task; depth=info.depth; }
+    }else if(r.type==='diy'){
+      const info=getDiyTaskInfo(r.id);
+      if(info){ task=info.task; depth=info.depth; }
+    }else if(arr){
+      task=arr.find(t=>t.id===r.id);
+    }
     if(!task) return;
     if(r.type==='work'){
-      todayTasks.push({category:'work',type:'work',item:task});
+      todayTasks.push({category:'work',type:'work',item:task,depth});
+      return;
+    } else if(r.type==='diy'){
+      todayTasks.push({category:'diy',type:'diy',item:task,depth});
       return;
     } else if(r.type==='stretch'){
       todayTasks.push({category:'stretch',type:'stretch',item:task});
       return;
     } else if(r.type==='big'){
       todayTasks.push({category:'big',type:'big',item:task});
+      return;
+    } else if(r.type==='diybig'){
+      todayTasks.push({category:'diybig',type:'diybig',item:task});
       return;
     }
     let i=overdueTasks.findIndex(o=>o.type===r.type&&o.item.id===r.id);
@@ -189,7 +252,7 @@ function renderSide(){
   overdueTasks.forEach((t,i)=>{
     const li=document.createElement('li');
     li.className='overdue';
-    li.textContent=`${t.item.name} (${t.item.project})`;
+    li.textContent=`[Todo - ${t.type}] ${t.item.name} (${t.item.project})`;
     const b=document.createElement('button');
     b.textContent='Select';
     b.onclick=()=>selectTask(t,i,'overdue');
@@ -210,7 +273,7 @@ function renderSide(){
       info='due '+formatUK(t.item.dueDate);
     }
     if(t.soon) info+=' (soon)';
-    li.textContent=`${t.item.name} (${t.item.project}) ${info}`;
+    li.textContent=`[Todo - ${t.type}] ${t.item.name} (${t.item.project}) ${info}`;
     const b=document.createElement('button');
     b.textContent='Select';
     b.onclick=()=>selectTask(t,i,'due');
@@ -221,13 +284,16 @@ function renderSide(){
   if(document.getElementById('diyToggle').checked) renderDiyTasks();
   if(document.getElementById('stretchToggle').checked) renderStretchTasks();
   if(document.getElementById('bigToggle').checked) renderBigTasks();
+  if(document.getElementById('diyBigToggle').checked) renderDiyBigTasks();
 }
 function renderWorkTasks(){
   const ul=document.getElementById('workTaskList');
   ul.innerHTML='';
-  workTasks.filter(t=>t.status==='open').forEach(t=>{
+  forEachWorkTask((t,depth)=>{
+    if(t.status!=='open') return;
     const li=document.createElement('li');
-    li.textContent=`${t.name} (${t.project})`;
+    li.style.paddingLeft=(depth)+'rem';
+    li.textContent=`[Work] ${t.name} (${t.project})`;
     const b=document.createElement('button');
     b.textContent='Add';
     b.onclick=()=>addWorkToToday(t.id);
@@ -238,9 +304,11 @@ function renderWorkTasks(){
 function renderDiyTasks(){
   const ul=document.getElementById('diyTaskList');
   ul.innerHTML='';
-  diyTasks.filter(t=>t.status==='open').forEach(t=>{
+  forEachDiyTask((t,depth)=>{
+    if(t.status!=='open') return;
     const li=document.createElement('li');
-    li.textContent=`${t.name} (${t.project})`;
+    li.style.paddingLeft=(depth)+'rem';
+    li.textContent=`[DIY] ${t.name} (${t.project})`;
     const b=document.createElement('button');
     b.textContent='Add';
     b.onclick=()=>addDiyToToday(t.id);
@@ -253,7 +321,7 @@ function renderStretchTasks(){
   ul.innerHTML='';
   stretchTasks.filter(t=>t.status==='open').forEach(t=>{
     const li=document.createElement('li');
-    li.textContent=`${t.name} (${t.project})`;
+    li.textContent=`[Todo - stretch] ${t.name} (${t.project})`;
     const b=document.createElement('button');
     b.textContent='Add';
     b.onclick=()=>addStretchToToday(t.id);
@@ -266,7 +334,7 @@ function renderBigTasks(){
   ul.innerHTML='';
   bigTasks.filter(t=>t.status==='open').forEach(t=>{
     const li=document.createElement('li');
-    li.textContent=`${t.name} (${t.project})`;
+    li.textContent=`[Todo - big] ${t.name} (${t.project})`;
     const b=document.createElement('button');
     b.textContent='Add';
     b.onclick=()=>addBigToToday(t.id);
@@ -274,17 +342,26 @@ function renderBigTasks(){
     ul.appendChild(li);
   });
 }
+function renderDiyBigTasks(){
+  const ul=document.getElementById('diyBigTaskList');
+  ul.innerHTML='';
+  diyBigTasks.filter(t=>t.status==='open').forEach(t=>{
+    const li=document.createElement('li');
+    li.textContent=`[DIY - big] ${t.name} (${t.project})`;
+    const b=document.createElement('button');
+    b.textContent='Add';
+    b.onclick=()=>addDiyBigToToday(t.id);
+    li.appendChild(b);
+    ul.appendChild(li);
+  });
+}
 function updateToggles(){
   const wt=document.getElementById('workToggle');
   const dt=document.getElementById('diyToggle');
-  const hasWork=todayTasks.some(t=>t.type==='work');
-  const hasDiy=todayTasks.some(t=>t.type==='diy');
-  wt.disabled=hasWork;
-  dt.disabled=hasDiy;
-  document.getElementById('workTaskList').classList.toggle('hidden',!wt.checked);
-  document.getElementById('diyTaskList').classList.toggle('hidden',!dt.checked);
-  if(hasWork) wt.checked=true;
-  if(hasDiy) dt.checked=true;
+  const db=document.getElementById('diyBigToggle');
+  document.getElementById('workTaskList').classList.toggle('hidden', !wt.checked);
+  document.getElementById('diyTaskList').classList.toggle('hidden', !dt.checked);
+  document.getElementById('diyBigTaskList').classList.toggle('hidden', !db.checked);
 }
 function renderToday(){
   const ul=document.getElementById('todayList');
@@ -294,17 +371,40 @@ function renderToday(){
     li.className='today-item';
     li.draggable=true;
     li.dataset.index=i;
+    if(t.depth) li.style.paddingLeft=(t.depth)+'rem';
     const text=document.createElement('span');
-    text.textContent=`${t.item.name} (${t.item.project})`;
+    let page='';
+    if(['oneoff','recurring','weekly','stretch','big'].includes(t.type)) page='Todo';
+    else if(t.type==='work') page='Work';
+    else if(t.type==='diy' || t.type==='diybig') page='DIY';
+    let label=`${t.item.name} (${t.item.project})`;
+    if(t.type==='big' || t.type==='diybig') label='[BIG] '+label;
+    let info='';
+    if(page==='Todo'){info=t.type;}
+    else if(page==='Work'){info=t.item.project;}
+    const prefix=page?`[${page}${info?` - ${info}`:''}] `:'';
+    text.textContent=prefix+label;
+    if(taskScheduledToday(t.type,t.item.id)) text.style.fontWeight='bold';
     const btnBox=document.createElement('span');
+    const up=document.createElement('button');
+    up.textContent='Up';
+    up.onclick=()=>moveTodayUp(i);
+    const down=document.createElement('button');
+    down.textContent='Down';
+    down.onclick=()=>moveTodayDown(i);
     const btnR=document.createElement('button');
     btnR.textContent='Remove';
     btnR.onclick=()=>removeToday(i);
     const btnC=document.createElement('button');
     btnC.textContent='Complete';
     btnC.onclick=()=>completeToday(i);
+    btnBox.appendChild(up);
+    btnBox.appendChild(down);
     btnBox.appendChild(btnR);
     btnBox.appendChild(btnC);
+    const num=document.createElement('span');
+    num.textContent=(i+1)+'. ';
+    li.appendChild(num);
     li.appendChild(text);
     li.appendChild(btnBox);
     ul.appendChild(li);
@@ -321,18 +421,18 @@ function selectTask(t,idx,list){
   updateToggles();
 }
 function addWorkToToday(id){
-  const task=workTasks.find(t=>t.id===id);
-  if(!task) return;
-  todayTasks.push({category:'work',type:'work',item:task});
+  const info=getWorkTaskInfo(id);
+  if(!info) return;
+  todayTasks.push({category:'work',type:'work',item:info.task,depth:info.depth});
   todayList.push({type:'work',id});
   saveData();
   renderToday();
   updateToggles();
 }
 function addDiyToToday(id){
-  const task=diyTasks.find(t=>t.id===id);
-  if(!task) return;
-  todayTasks.push({category:'diy',type:'diy',item:task});
+  const info=getDiyTaskInfo(id);
+  if(!info) return;
+  todayTasks.push({category:'diy',type:'diy',item:info.task,depth:info.depth});
   todayList.push({type:'diy',id});
   saveData();
   renderToday();
@@ -351,6 +451,30 @@ function addBigToToday(id){
   if(!task) return;
   todayTasks.push({category:'big',type:'big',item:task});
   todayList.push({type:'big',id});
+  saveData();
+  renderToday();
+}
+function addDiyBigToToday(id){
+  const task=diyBigTasks.find(t=>t.id===id);
+  if(!task) return;
+  todayTasks.push({category:'diybig',type:'diybig',item:task});
+  todayList.push({type:'diybig',id});
+  saveData();
+  renderToday();
+}
+
+function moveTodayUp(idx){
+  if(idx<=0) return;
+  [todayTasks[idx-1],todayTasks[idx]]=[todayTasks[idx],todayTasks[idx-1]];
+  [todayList[idx-1],todayList[idx]]=[todayList[idx],todayList[idx-1]];
+  saveData();
+  renderToday();
+}
+
+function moveTodayDown(idx){
+  if(idx>=todayTasks.length-1) return;
+  [todayTasks[idx],todayTasks[idx+1]]=[todayTasks[idx+1],todayTasks[idx]];
+  [todayList[idx],todayList[idx+1]]=[todayList[idx+1],todayList[idx]];
   saveData();
   renderToday();
 }
@@ -410,6 +534,9 @@ function completeToday(idx){
     t.item.completedDates.push(formatISO(now));
     t.item.status='closed';
     t.item.closedDate=formatISO(now);
+  }else if(t.type==='diybig'){
+    t.item.status='closed';
+    saveDiyData();
   }
   if(t.category==='overdue'){/* do nothing */}
   else if(t.category==='due'){/* keep order */}
@@ -436,6 +563,11 @@ document.getElementById('stretchToggle').addEventListener('change',e=>{
 document.getElementById('bigToggle').addEventListener('change',e=>{
   document.getElementById('bigTaskList').classList.toggle('hidden',!e.target.checked);
   if(e.target.checked) renderBigTasks();
+});
+document.getElementById('diyBigToggle').addEventListener('change',e=>{
+  document.getElementById('diyBigTaskList').classList.toggle('hidden',!e.target.checked);
+  if(e.target.checked) renderDiyBigTasks();
+  updateToggles();
 });
 async function init(){await loadData();categorize();rebuildToday();renderSide();renderToday();}
 init();

--- a/work.html
+++ b/work.html
@@ -23,6 +23,8 @@ section { padding:1rem; border-bottom:10px solid pink; }
 .form-grid input,.form-grid select{ width:100%; font-size:1rem; padding:0.4rem; }
 .hidden{ display:none !important; }
 .task-row{ display:grid; grid-template-columns:2fr 1fr 1fr 1fr 1fr; gap:0.25rem; align-items:center; border:1px solid #ccc; padding:0.25rem; margin-top:0.25rem; }
+#taskList{max-height:400px;overflow-y:auto;overflow-x:hidden;width:calc(100% - 1rem);padding-right:1rem;}
+.task-row div{word-break:break-word;}
 .subtask{ margin-left:1rem; }
 .controls button{ margin-left:0.25rem; font-size:0.7rem; }
 .filter-grid{ display:flex; gap:0.5rem; flex-wrap:wrap; margin-bottom:0.5rem; }
@@ -518,13 +520,14 @@ function renderTasks(){
 function renderCalendarTasks(){
   const cont=document.getElementById('calendarTaskList');
   cont.innerHTML='';
-  forEachTask(t=>{
+  forEachTask((t,depth)=>{
     if(t.status!=='open') return;
     const div=document.createElement('div');
     div.className='fc-task';
     div.textContent=t.name;
     div.dataset.id=t.id;
     div.dataset.title=t.name;
+    div.style.marginLeft=depth+'rem';
     cont.appendChild(div);
   });
   if(calendarDraggable){
@@ -574,20 +577,29 @@ function meetingStatus(date){
   return 'meeting-upcoming';
 }
 
+function formatShortUK(date){
+  const d=new Date(date);
+  if(isNaN(d)) return '';
+  return d.toLocaleDateString('en-GB',{day:'2-digit',month:'short',year:'2-digit'});
+}
+
 function renderMeetings(){
   const colsCont=document.getElementById('meetingColumns');
   const allCont=document.getElementById('allMeetings');
   colsCont.innerHTML='';
   allCont.innerHTML='';
-  const projects=[...workProjects.map(p=>p.name), 'Ad Hoc'];
+  const projects=[...new Set(meetings.map(m=>m.project||'Ad Hoc'))];
   projects.forEach(name=>{
+    const projectMeetings=meetings.filter(m=>(m.project||'Ad Hoc')===name);
+    if(projectMeetings.length===0) return;
     const col=document.createElement('div');
     col.className='meeting-col';
     col.innerHTML='<h3>'+name+'</h3>';
-    meetings.filter(m=> (m.project||'Ad Hoc')===name).forEach(m=>{
+    projectMeetings.forEach(m=>{
       const card=document.createElement('div');
       card.className='meeting-card '+meetingStatus(m.date);
-      card.textContent=m.title;
+      const date=formatShortUK(m.date);
+      card.textContent=date?`${m.title} - ${date}`:m.title;
       card.onclick=()=>openMeetingModal(m.id);
       col.appendChild(card);
       allCont.appendChild(card.cloneNode(true));


### PR DESCRIPTION
## Summary
- label task lists with their source page so it's clear where each task comes from
- show '[Todo - TYPE]' on overdue and due lists
- include '[Work]' and '[DIY]' tags in selectable lists
- display origin labels in Today items and allow ordering with Up/Down buttons
- hide empty meeting sections and show meeting dates

## Testing
- `npm install >/tmp/npm.log && tail -n 20 /tmp/npm.log`
- `node server.js >/tmp/node.log 2>&1 & pid=$!; sleep 2; kill $pid; cat /tmp/node.log`


------
https://chatgpt.com/codex/tasks/task_e_6887552cd908832fab414b0475525e3e