### PR TITLE
Add budget periods and monthly overview

### DIFF
--- a/finance.html
+++ b/finance.html
@@ -1,0 +1,656 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Finance Manager</title>
+<style>
+body{font-family:'Segoe UI',Tahoma,sans-serif;margin:0;padding:0;}
+header{background:#fff;color:#ff69b4;padding:1rem;text-align:center;border-bottom:1px solid #ddd;}
+.tabs{display:flex;gap:0.5rem;padding:0.5rem;background:#eee;justify-content:center;}
+.tabs button{padding:0.5rem 1rem;border:none;background:#cfe2ff;cursor:pointer;}
+.tab-content{display:none;padding:1rem;}
+.tab-content.active{display:block;}
+table{border-collapse:collapse;width:100%;margin-top:1rem;font-size:0.9rem;}
+th,td{border:1px solid #ccc;padding:0.25rem 0.5rem;}
+</style>
+</head>
+<body>
+<header>
+  <h1>Finance Manager</h1>
+  <div id="nav-placeholder"></div>
+</header>
+<script src="nav-loader.js"></script>
+<div class="tabs">
+  <button onclick="showTab('upload')">Upload</button>
+  <button onclick="showTab('code')">Code</button>
+  <button onclick="showTab('budgets')">Budgets</button>
+</div>
+<div id="upload" class="tab-content active">
+  <h2>Upload Transactions</h2>
+  <form id="upload-form">
+    <label>Account Type
+      <select id="account-type">
+        <option value="TSB">TSB</option>
+        <option value="Monzo">Monzo</option>
+        <option value="Credit Card">Credit Card</option>
+      </select>
+    </label>
+    <label>Account Name
+      <select id="account-name" required></select>
+    </label>
+    <input type="file" id="file-input" accept=".csv,.xls,.xlsx" required>
+    <button type="submit">Upload</button>
+  </form>
+  <div id="upload-msg"></div>
+  <h3>Accounts</h3>
+  <ul id="accounts-display"></ul>
+  <input type="text" id="new-account" placeholder="Add account">
+  <button id="add-account">Add</button>
+  <datalist id="type-list"></datalist>
+</div>
+<div id="code" class="tab-content">
+  <h2>Transactions</h2>
+  <label><input type="checkbox" id="filter-uncoded">Uncoded only</label>
+  <button id="show-duplicates" type="button">Show Duplicates</button>
+  <button id="download-excel" type="button">Download Excel</button>
+  <div id="filter-controls" style="margin-top:0.5rem;">
+    <input type="text" id="search-text" placeholder="Search description">
+    <select id="filter-account"><option value="">All accounts</option></select>
+    <select id="filter-type"><option value="">All types</option></select>
+    <input type="date" id="filter-date-from">
+    <input type="date" id="filter-date-to">
+    <input type="number" id="filter-amount-min" placeholder="Min">
+    <input type="number" id="filter-amount-max" placeholder="Max">
+    <button id="apply-filters" type="button">Apply</button>
+  </div>
+  <table id="tx-table">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Description</th>
+        <th>Amount</th>
+        <th>Account</th>
+        <th>Type</th>
+        <th>Sub Type</th>
+        <th>Confirmed</th>
+        <th>Transfer</th>
+        <th>Notes</th>
+        <th>Month</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+  <div id="duplicates-modal" style="display:none;position:fixed;top:10%;left:10%;right:10%;background:#fff;border:1px solid #ccc;padding:1rem;max-height:80%;overflow:auto;">
+    <button id="close-duplicates" type="button">Close</button>
+    <table id="duplicates-table">
+      <thead>
+        <tr><th>Date</th><th>Description</th><th>Amount</th><th>Account</th><th>File</th><th>Action</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+  <h3>Autofill Rules</h3>
+  <form id="rule-form">
+    <input type="text" id="rule-desc" placeholder="Description contains" required>
+    <select id="rule-type"><option value="">Select type</option></select>
+    <input type="text" id="rule-subtype" placeholder="Sub type" list="rule-subtype-list">
+    <button type="submit">Add Rule</button>
+  </form>
+  <table id="rule-table">
+    <thead><tr><th>Match</th><th>Type</th><th>Sub Type</th><th>Action</th></tr></thead>
+    <tbody></tbody>
+  </table>
+  <datalist id="rule-subtype-list"></datalist>
+</div>
+<div id="budgets" class="tab-content">
+  <h2>Budgets</h2>
+  <form id="budget-form">
+    <input type="text" id="budget-name" placeholder="Category" required>
+    <input type="number" id="budget-amount" placeholder="Amount" required>
+    <input type="text" id="budget-subtypes" placeholder="Sub types comma separated">
+    <label><input type="checkbox" id="budget-recurring">Recurring</label>
+    <input type="date" id="budget-date">
+    <button type="submit">Add Budget</button>
+  </form>
+  <table id="budget-table">
+    <thead>
+      <tr><th>Name</th><th>Amount</th><th>Recurring</th><th>Date</th><th>Sub Types</th><th>Archived</th></tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+  <h3>Budget Periods</h3>
+  <form id="period-form">
+    <input type="date" id="period-start" required>
+    <input type="text" id="period-label" placeholder="Label" required>
+    <button type="submit">Add Period</button>
+  </form>
+  <table id="period-table">
+    <thead><tr><th>Start</th><th>Label</th></tr></thead>
+    <tbody></tbody>
+  </table>
+
+  <h3>Budget Overview</h3>
+  <label>Month <select id="overview-month"></select></label>
+  <label><input type="checkbox" id="show-budgeted" checked>Show Budgeted</label>
+  <label><input type="checkbox" id="show-remaining" checked>Show Remaining</label>
+  <label><input type="checkbox" id="toggle-archived">View Archived Budgets</label>
+  <table id="overview-table">
+    <thead><tr></tr></thead>
+    <tbody></tbody>
+  </table>
+</div>
+<script src="node_modules/papaparse/papaparse.min.js"></script>
+<script src="node_modules/xlsx/dist/xlsx.full.min.js"></script>
+<script>
+let financeData = { accounts: [], transactions: [], nextTransactionId: 1, budgets: [], nextBudgetId: 1, rules: [], budgetPeriods: [] };
+
+function showTab(id){
+  document.querySelectorAll('.tab-content').forEach(div=>div.classList.remove('active'));
+  const el=document.getElementById(id);
+  if(el) el.classList.add('active');
+}
+
+async function loadFinance(){
+  const res = await fetch('/api/finance-data');
+  financeData = await res.json();
+  if(!financeData.budgets.some(b=>b.name==='Other \u2013 Budgeted')){
+    financeData.budgets.push({id:financeData.nextBudgetId++,name:'Other \u2013 Budgeted',amount:0,recurring:false,subTypes:[]});
+  }
+  if(!financeData.budgets.some(b=>b.name==='Other \u2013 Not Budgeted')){
+    financeData.budgets.push({id:financeData.nextBudgetId++,name:'Other \u2013 Not Budgeted',amount:0,recurring:false,subTypes:[]});
+  }
+  applyRulesToAll();
+  assignMonthsAll();
+  await saveFinance();
+  checkDuplicates();
+  updateAccountList();
+  renderTransactions();
+  renderBudgets();
+  renderRules();
+  renderPeriods();
+  populateOverviewMonths();
+  renderOverview();
+}
+
+function updateAccountList(){
+  const sel = document.getElementById('account-name');
+  if(sel){
+    sel.innerHTML = '';
+    financeData.accounts.forEach(a=>{
+      const o=document.createElement('option');
+      o.value=a; o.textContent=a; sel.appendChild(o);
+    });
+  }
+  const ul = document.getElementById('accounts-display');
+  if(ul){ ul.innerHTML=''; financeData.accounts.forEach(a=>{ const li=document.createElement('li'); li.textContent=a; ul.appendChild(li); }); }
+  const filterSel = document.getElementById('filter-account');
+  if(filterSel){
+    filterSel.innerHTML = '<option value="">All accounts</option>';
+    financeData.accounts.forEach(a=>{ const opt=document.createElement('option'); opt.value=a; opt.textContent=a; filterSel.appendChild(opt); });
+  }
+}
+
+function getMonth(dateStr){
+  const d = new Date(dateStr);
+  if(Number.isNaN(d.getTime())) return '';
+  return d.toLocaleString('default',{month:'long',year:'numeric'});
+}
+
+function assignMonth(tx){
+  if(!tx.date) { tx.month=''; return; }
+  if(financeData.budgetPeriods && financeData.budgetPeriods.length){
+    const sorted = financeData.budgetPeriods.slice().sort((a,b)=>new Date(a.start)-new Date(b.start));
+    let label = getMonth(tx.date);
+    for(const p of sorted){
+      if(new Date(tx.date) >= new Date(p.start)) label = p.label; else break;
+    }
+    tx.month = label;
+  } else {
+    tx.month = getMonth(tx.date);
+  }
+}
+
+function assignMonthsAll(){
+  financeData.transactions.forEach(t=>assignMonth(t));
+}
+
+function applyRules(tx){
+  const matches = [];
+  financeData.rules.forEach(r=>{
+    if(tx.description && tx.description.toLowerCase().includes(r.match.toLowerCase())){
+      matches.push(r);
+    }
+  });
+  if(matches.length===1){
+    tx.type = matches[0].type;
+    tx.subType = matches[0].subType || '';
+    tx.autofill = true;
+    tx.confirmed = false;
+  } else if(matches.length>1){
+    tx.multipleRules = matches.map(m=>m.id);
+    tx.autofill = true;
+    tx.confirmed = false;
+  }
+}
+
+function applyRulesToAll(){
+  financeData.transactions.forEach(tx=>{
+    if(!tx.type){
+      applyRules(tx);
+    }
+  });
+}
+
+function checkDuplicates(){
+  const seen = {};
+  financeData.transactions.forEach(tx=>{
+    const key = tx.date+'|'+tx.description+'|'+tx.amount+'|'+tx.accountName;
+    if(seen[key]){
+      tx.duplicate = true;
+      seen[key].duplicate = true;
+    } else {
+      seen[key] = tx;
+      if(!tx.hasOwnProperty('duplicate')) tx.duplicate = false;
+    }
+  });
+}
+
+function renderTransactions(){
+  const tbody = document.querySelector("#tx-table tbody");
+  tbody.innerHTML = "";
+  const uncoded = document.getElementById("filter-uncoded").checked;
+  const search = document.getElementById('search-text').value.toLowerCase();
+  const fAcc = document.getElementById('filter-account').value;
+  const fType = document.getElementById('filter-type').value;
+  const fFrom = document.getElementById('filter-date-from').value;
+  const fTo = document.getElementById('filter-date-to').value;
+  const fMin = parseFloat(document.getElementById('filter-amount-min').value);
+  const fMax = parseFloat(document.getElementById('filter-amount-max').value);
+  financeData.transactions.forEach(tx=>{
+    if(uncoded && tx.type) return;
+    if(fAcc && tx.accountName !== fAcc) return;
+    if(fType && tx.type !== fType) return;
+    if(search && !tx.description.toLowerCase().includes(search)) return;
+    if(fFrom && new Date(tx.date) < new Date(fFrom)) return;
+    if(fTo && new Date(tx.date) > new Date(fTo)) return;
+    if(!Number.isNaN(fMin) && parseFloat(tx.amount) < fMin) return;
+    if(!Number.isNaN(fMax) && parseFloat(tx.amount) > fMax) return;
+    const tr = document.createElement("tr");
+    tr.innerHTML = `<td>${tx.date}</td><td>${tx.description}</td><td>${tx.amount}</td><td>${tx.accountName}</td>`;
+    if(tx.duplicate) tr.style.background = "#fdd";
+    if(tx.autofill && !tx.confirmed) tr.style.background = "#ffffcc";
+    if(tx.multipleRules && tx.multipleRules.length>1) tr.style.background = "#fcc";
+    const typeSel = document.createElement("input");
+    typeSel.setAttribute('list','type-list');
+    typeSel.value = tx.type || "";
+    typeSel.addEventListener("change", ()=>{ tx.type = typeSel.value; tx.confirmed = true; tx.autofill=false; saveFinance(); renderTransactions(); });
+    const subTypeInput = document.createElement("input");
+    const stList = document.createElement('datalist');
+    const stId = 'st-list-'+tx.id;
+    stList.id = stId;
+    subTypeInput.setAttribute('list', stId);
+    subTypeInput.value = tx.subType || '';
+    function populateST(){
+      const budget = financeData.budgets.find(b=>b.name===typeSel.value);
+      stList.innerHTML='';
+      if(budget){
+        budget.subTypes = budget.subTypes || [];
+        budget.subTypes.forEach(s=>{const o=document.createElement('option');o.value=s;stList.appendChild(o);});
+      }
+    }
+    populateST();
+    typeSel.addEventListener('change', populateST);
+    subTypeInput.addEventListener('change', ()=>{ tx.subType = subTypeInput.value; tx.autofill=false; saveFinance(); });
+    const saveSubBtn = document.createElement('button');
+    saveSubBtn.textContent = '+';
+    saveSubBtn.type = 'button';
+    saveSubBtn.addEventListener('click', ()=>{
+      const budget = financeData.budgets.find(b=>b.name===typeSel.value);
+      if(budget && subTypeInput.value && !budget.subTypes.includes(subTypeInput.value)){
+        budget.subTypes.push(subTypeInput.value);
+        populateST();
+        saveFinance();
+        renderBudgets();
+      }
+    });
+    const confirmBox = document.createElement("input");
+    confirmBox.type = "checkbox";
+    confirmBox.checked = !!tx.confirmed;
+    confirmBox.addEventListener("change", ()=>{ tx.confirmed = confirmBox.checked; saveFinance(); });
+    const transferBox = document.createElement("input");
+    transferBox.type = "checkbox";
+    transferBox.checked = !!tx.transfer;
+    transferBox.addEventListener("change", ()=>{ tx.transfer = transferBox.checked; saveFinance(); });
+    const notes = document.createElement("input");
+    notes.value = tx.notes || "";
+    notes.addEventListener("change", ()=>{ tx.notes = notes.value; saveFinance(); });
+    const tdType = document.createElement("td"); tdType.appendChild(typeSel);
+    const tdSub = document.createElement('td'); tdSub.appendChild(subTypeInput); tdSub.appendChild(stList); tdSub.appendChild(saveSubBtn);
+    const tdConf = document.createElement("td"); tdConf.appendChild(confirmBox);
+    const tdTrans = document.createElement("td"); tdTrans.appendChild(transferBox);
+    const tdNotes = document.createElement("td"); tdNotes.appendChild(notes);
+    const tdMonth = document.createElement("td"); tdMonth.textContent = tx.month || getMonth(tx.date);
+    tr.appendChild(tdType); tr.appendChild(tdSub); tr.appendChild(tdConf); tr.appendChild(tdTrans); tr.appendChild(tdNotes); tr.appendChild(tdMonth);
+    tbody.appendChild(tr);
+  });
+}
+
+function renderBudgets(){
+  const tbody = document.querySelector('#budget-table tbody');
+  tbody.innerHTML = '';
+  financeData.budgets.forEach(b=>{
+    const tr = document.createElement('tr');
+    const subs = (b.subTypes||[]).join(', ');
+    tr.innerHTML = `<td>${b.name}</td><td>${b.amount}</td><td>${b.recurring ? 'Yes':'No'}</td><td>${b.date||''}</td><td>${subs}</td>`;
+    const arch = document.createElement('input');
+    arch.type = 'checkbox';
+    arch.checked = !!b.archived;
+    arch.addEventListener('change',()=>{ b.archived = arch.checked; saveFinance(); renderOverview(); });
+    const tdArch = document.createElement('td'); tdArch.appendChild(arch); tr.appendChild(tdArch);
+    tbody.appendChild(tr);
+  });
+  updateTypeOptions();
+}
+
+function updateTypeOptions(){
+  const list = document.getElementById('type-list');
+  if(list) list.innerHTML = '';
+  const filter = document.getElementById('filter-type');
+  if(filter) filter.innerHTML = '<option value="">All types</option>';
+  financeData.budgets.forEach(b=>{
+    if(list){ const opt=document.createElement('option'); opt.value=b.name; list.appendChild(opt); }
+    if(filter){ const opt=document.createElement('option'); opt.value=b.name; opt.textContent=b.name; filter.appendChild(opt); }
+  });
+  const ruleType = document.getElementById('rule-type');
+  if(ruleType){
+    ruleType.innerHTML = '<option value="">Select type</option>';
+    financeData.budgets.forEach(b=>{
+      const o=document.createElement('option'); o.value=b.name; o.textContent=b.name; ruleType.appendChild(o);
+    });
+  }
+}
+
+function renderRules(){
+  const tbody = document.querySelector('#rule-table tbody');
+  if(!tbody) return;
+  tbody.innerHTML='';
+  financeData.rules.forEach(r=>{
+    const tr=document.createElement('tr');
+    const delBtn=document.createElement('button');
+    delBtn.textContent='Delete';
+    delBtn.addEventListener('click',()=>{
+      financeData.rules=financeData.rules.filter(x=>x.id!==r.id);
+      saveFinance();
+      renderRules();
+    });
+    tr.innerHTML=`<td>${r.match}</td><td>${r.type}</td><td>${r.subType||''}</td>`;
+    const td=document.createElement('td'); td.appendChild(delBtn); tr.appendChild(td);
+    tbody.appendChild(tr);
+  });
+  document.getElementById('rule-desc').value='';
+  document.getElementById('rule-subtype').value='';
+}
+
+async function saveFinance(){
+  checkDuplicates();
+  await fetch('/api/finance-data', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(financeData) });
+}
+
+document.getElementById('upload-form').addEventListener('submit', async e=>{
+  e.preventDefault();
+  const file = document.getElementById('file-input').files[0];
+  if(!file) return;
+  const accountType = document.getElementById('account-type').value;
+  const accountName = document.getElementById('account-name').value.trim();
+  if(accountName && !financeData.accounts.includes(accountName)){
+    financeData.accounts.push(accountName);
+  }
+  parseFile(file, accountType, accountName);
+});
+
+function parseFile(file, accountType, accountName){
+  const reader = new FileReader();
+  const ext = file.name.split('.').pop().toLowerCase();
+  reader.onload = async () => {
+    let rows = [];
+    if(ext === 'csv'){
+      rows = Papa.parse(reader.result, { header:true }).data;
+    } else {
+      const wb = XLSX.read(reader.result, { type:'binary' });
+      const sheet = wb.Sheets[wb.SheetNames[0]];
+      rows = XLSX.utils.sheet_to_json(sheet);
+    }
+    rows.forEach(r=>{
+      let date='';
+      let description='';
+      let amount='';
+      if(accountType === 'Monzo'){
+        date = r.Date || r.date;
+        description = r.Description || r.Name || r.name || '';
+        if(r['Money Out']) amount = -parseFloat(r['Money Out']);
+        if(r['Money In']) amount = parseFloat(r['Money In']);
+        if(r.Amount) amount = parseFloat(r.Amount);
+      } else {
+        const keys = Object.keys(r).slice(0,8);
+        keys.forEach(k=>{
+          const lower=k.toLowerCase();
+          if(lower.includes('description')) description = r[k];
+          if(lower === 'date' || lower.startsWith('date ')) date = r[k];
+          if(lower.includes('amount')) amount = r[k];
+        });
+      }
+      const tx = {
+        id: financeData.nextTransactionId++,
+        date,
+        description,
+        amount: parseFloat(amount || 0),
+        accountType,
+        accountName,
+        month: '',
+        sourceFile: file.name,
+        uploadedAt: new Date().toISOString(),
+        notes: '',
+        transfer: false
+      };
+      assignMonth(tx);
+      applyRules(tx);
+      financeData.transactions.push(tx);
+    });
+    checkDuplicates();
+    await saveFinance();
+    updateAccountList();
+    renderTransactions();
+    populateOverviewMonths();
+    renderOverview();
+    showTab('code');
+    document.getElementById('upload-msg').textContent = 'Uploaded '+rows.length+' rows.';
+  };
+  if(ext === 'csv') reader.readAsText(file); else reader.readAsBinaryString(file);
+}
+
+document.getElementById('budget-form').addEventListener('submit', async e=>{
+  e.preventDefault();
+  const name = document.getElementById('budget-name').value.trim();
+  const amt = parseFloat(document.getElementById('budget-amount').value);
+  const subs = document.getElementById('budget-subtypes').value.split(',').map(s=>s.trim()).filter(s=>s);
+  const rec = document.getElementById('budget-recurring').checked;
+  const date = document.getElementById('budget-date').value;
+  if(!name) return;
+  financeData.budgets.push({ id: financeData.nextBudgetId++, name, amount: amt, subTypes: subs, recurring: rec, date, archived:false });
+  document.getElementById('budget-name').value='';
+  document.getElementById('budget-amount').value='';
+  document.getElementById('budget-subtypes').value='';
+  document.getElementById('budget-recurring').checked=false;
+  document.getElementById('budget-date').value='';
+  await saveFinance();
+  renderBudgets();
+  renderOverview();
+  populateOverviewMonths();
+});
+
+window.addEventListener('DOMContentLoaded', loadFinance);
+document.getElementById('add-account').addEventListener('click', () => {
+  const name = document.getElementById('new-account').value.trim();
+  if(!name || financeData.accounts.includes(name)) return;
+  financeData.accounts.push(name);
+  document.getElementById('new-account').value='';
+  updateAccountList();
+  saveFinance();
+});
+
+document.getElementById('filter-uncoded').addEventListener('change', renderTransactions);
+
+document.getElementById('apply-filters').addEventListener('click', () => {
+  renderTransactions();
+});
+
+document.getElementById('show-duplicates').addEventListener('click', () => {
+  renderDuplicates();
+  document.getElementById('duplicates-modal').style.display = 'block';
+});
+
+document.getElementById('download-excel').addEventListener('click', async () => {
+  const res = await fetch('/api/finance-export');
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'finance-master.xlsx';
+  a.click();
+  URL.revokeObjectURL(url);
+});
+
+document.getElementById('close-duplicates').addEventListener('click', () => {
+  document.getElementById('duplicates-modal').style.display = 'none';
+});
+
+document.getElementById('rule-form').addEventListener('submit', e=>{
+  e.preventDefault();
+  const match = document.getElementById('rule-desc').value.trim();
+  const type = document.getElementById('rule-type').value;
+  const sub = document.getElementById('rule-subtype').value.trim();
+  if(!match || !type) return;
+  financeData.rules.push({ id: Date.now(), match, type, subType: sub });
+  document.getElementById('rule-desc').value='';
+  document.getElementById('rule-subtype').value='';
+  saveFinance();
+  renderRules();
+  applyRulesToAll();
+  renderTransactions();
+});
+
+document.getElementById('rule-type').addEventListener('change', () => {
+  const type = document.getElementById('rule-type').value;
+  const list = document.getElementById('rule-subtype-list');
+  list.innerHTML='';
+  const budget = financeData.budgets.find(b=>b.name===type);
+  if(budget){
+    (budget.subTypes||[]).forEach(s=>{const o=document.createElement('option');o.value=s;list.appendChild(o);});
+  }
+});
+
+function renderDuplicates(){
+  const tbody = document.querySelector('#duplicates-table tbody');
+  tbody.innerHTML = '';
+  financeData.transactions.filter(t=>t.duplicate).forEach(tx=>{
+    const tr = document.createElement('tr');
+    const keepBtn = document.createElement('button');
+    keepBtn.textContent = 'Keep';
+    keepBtn.addEventListener('click', ()=>{ tx.duplicate=false; saveFinance(); renderTransactions(); renderDuplicates(); });
+    const removeBtn = document.createElement('button');
+    removeBtn.textContent = 'Remove';
+    removeBtn.addEventListener('click', ()=>{ financeData.transactions = financeData.transactions.filter(t=>t.id!==tx.id); saveFinance(); renderTransactions(); renderDuplicates(); });
+    const tdAction = document.createElement('td');
+    tdAction.appendChild(keepBtn); tdAction.appendChild(removeBtn);
+    tr.innerHTML = `<td>${tx.date}</td><td>${tx.description}</td><td>${tx.amount}</td><td>${tx.accountName}</td><td>${tx.sourceFile}</td>`;
+    tr.appendChild(tdAction);
+    tbody.appendChild(tr);
+  });
+}
+
+function renderPeriods(){
+  const tbody=document.querySelector('#period-table tbody');
+  if(!tbody) return;
+  tbody.innerHTML='';
+  financeData.budgetPeriods.sort((a,b)=>new Date(a.start)-new Date(b.start)).forEach(p=>{
+    const tr=document.createElement('tr');
+    tr.innerHTML=`<td>${p.start}</td><td>${p.label}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+function populateOverviewMonths(){
+  const sel=document.getElementById('overview-month');
+  if(!sel) return;
+  const months=new Set(financeData.transactions.map(t=>t.month).filter(m=>m));
+  sel.innerHTML='';
+  const map={};
+  financeData.budgetPeriods.forEach(p=>{map[p.label]=new Date(p.start).getTime();});
+  Array.from(months).sort((a,b)=>{
+    return (map[a]||0)-(map[b]||0);
+  }).forEach(m=>{const o=document.createElement('option');o.value=m;o.textContent=m;sel.appendChild(o);});
+  if(sel.options.length) sel.value=sel.options[sel.options.length-1].value;
+}
+
+function renderOverview(){
+  const monthSel=document.getElementById('overview-month');
+  if(!monthSel) return;
+  const month=monthSel.value;
+  const showBud=document.getElementById('show-budgeted').checked;
+  const showRem=document.getElementById('show-remaining').checked;
+  const showArch=document.getElementById('toggle-archived').checked;
+  const thead=document.querySelector('#overview-table thead tr');
+  thead.innerHTML='<th>Budget Item</th>'+(showBud?'<th>Budgeted</th>':'')+'<th>Spent</th>'+(showRem?'<th>Remaining</th>':'')+'<th>Status</th>';
+  const tbody=document.querySelector('#overview-table tbody');
+  tbody.innerHTML='';
+  financeData.budgets.forEach(b=>{
+    if(b.archived && !showArch) return;
+    const spent=financeData.transactions.filter(t=>t.type===b.name && t.month===month && !t.transfer).reduce((s,t)=>s+parseFloat(t.amount||0),0);
+    const rem=(b.amount||0)-spent;
+    const tr=document.createElement('tr');
+    let html=`<td>${b.name}</td>`;
+    if(showBud) html+=`<td>${b.amount||0}</td>`;
+    html+=`<td>${spent.toFixed(2)}</td>`;
+    if(showRem) html+=`<td style="color:${rem<0?'red':'green'}">${rem.toFixed(2)}</td>`;
+    html+=`<td>${rem>=0?'\u2705':'\u274c'}</td>`;
+    tr.innerHTML=html;
+    tbody.appendChild(tr);
+    (b.subTypes||[]).forEach(sub=>{
+      const spentSub=financeData.transactions.filter(t=>t.type===b.name && t.subType===sub && t.month===month && !t.transfer).reduce((s,t)=>s+parseFloat(t.amount||0),0);
+      const tr2=document.createElement('tr');
+      let h=`<td style="padding-left:20px;">${sub}</td>`;
+      if(showBud) h+='<td></td>';
+      h+=`<td>${spentSub.toFixed(2)}</td>`;
+      if(showRem) h+='<td></td>';
+      h+='<td></td>';
+      tr2.innerHTML=h;
+      tbody.appendChild(tr2);
+    });
+  });
+}
+
+document.getElementById('period-form').addEventListener('submit',e=>{
+  e.preventDefault();
+  const start=document.getElementById('period-start').value;
+  const label=document.getElementById('period-label').value.trim();
+  if(!start||!label) return;
+  financeData.budgetPeriods.push({start,label});
+  financeData.budgetPeriods.sort((a,b)=>new Date(a.start)-new Date(b.start));
+  document.getElementById('period-start').value='';
+  document.getElementById('period-label').value='';
+  assignMonthsAll();
+  saveFinance();
+  renderPeriods();
+  populateOverviewMonths();
+  renderOverview();
+  renderTransactions();
+});
+
+document.getElementById('overview-month').addEventListener('change',renderOverview);
+document.getElementById('show-budgeted').addEventListener('change',renderOverview);
+document.getElementById('show-remaining').addEventListener('change',renderOverview);
+document.getElementById('toggle-archived').addEventListener('change',renderOverview);
+</script>
+</body>
+</html>

--- a/financeData.json
+++ b/financeData.json
@@ -1,0 +1,9 @@
+{
+  "accounts": [],
+  "transactions": [],
+  "nextTransactionId": 1,
+  "budgets": [],
+  "nextBudgetId": 1,
+  "rules": [],
+  "budgetPeriods": []
+}

--- a/nav.html
+++ b/nav.html
@@ -6,6 +6,7 @@
   <a href="diy.html">DIY</a>
   <a href="work.html">Work</a>
   <a href="spending.html">Spending</a>
+  <a href="finance.html">Finance</a>
 </nav>
 <style>
   .main-nav {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "dotenv": "^17.2.1",
         "express": "^4.18.2",
-        "mongodb": "^6.17.0"
+        "mongodb": "^6.17.0",
+        "papaparse": "^5.5.3",
+        "xlsx": "^0.18.5"
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -48,6 +50,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/array-flatten": {
@@ -127,6 +138,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -162,6 +195,18 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -348,6 +393,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fresh": {
@@ -654,6 +708,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -897,6 +957,18 @@
         "memory-pager": "^1.0.2"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -987,6 +1059,45 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "dependencies": {
     "dotenv": "^17.2.1",
     "express": "^4.18.2",
-    "mongodb": "^6.17.0"
+    "mongodb": "^6.17.0",
+    "papaparse": "^5.5.3",
+    "xlsx": "^0.18.5"
   }
 }


### PR DESCRIPTION
## Summary
- support archived flag and monthly budget overview in Finance page
- allow defining custom budget periods with start date and label
- assign month labels to transactions using budget periods
- compute overview of budget vs spent with optional toggles
- map uploads to account dropdown and detect duplicates per account
- add Excel export and automatically switch to Code tab after upload

## Testing
- `npm install`
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_688b5412cd9c832f8c064cdb1e8c57ee