### PR TITLE
Fix tab handler registration for finance page

### DIFF
--- a/finance.html
+++ b/finance.html
@@ -1112,12 +1112,10 @@ function parseFile(file, accountType, accountName){
   if(ext === 'csv') reader.readAsText(file); else reader.readAsBinaryString(file);
 }
 
-window.addEventListener('DOMContentLoaded', () => {
-  loadFinance();
-  document.getElementById('tab-upload').addEventListener('click', () => showTab('upload'));
-  document.getElementById('tab-code').addEventListener('click', () => showTab('code'));
-  document.getElementById('tab-budgets').addEventListener('click', () => showTab('budgets'));
-});
+loadFinance();
+document.getElementById('tab-upload').addEventListener('click', () => showTab('upload'));
+document.getElementById('tab-code').addEventListener('click', () => showTab('code'));
+document.getElementById('tab-budgets').addEventListener('click', () => showTab('budgets'));
 document.getElementById('add-account').addEventListener('click', () => {
   const name = document.getElementById('new-account').value.trim();
   if(!name || financeData.accounts.includes(name)) return;


### PR DESCRIPTION
## Summary
- Register tab switch handlers directly instead of waiting for `DOMContentLoaded`

## Testing
- `node - <<'NODE'
const {JSDOM} = require('jsdom');
const html = `
<div class="tabs">
  <button id="tab-upload" type="button">Upload</button>
  <button id="tab-code" type="button">Code</button>
  <button id="tab-budgets" type="button">Budgets</button>
</div>
<div id="upload" class="tab-content active"></div>
<div id="code" class="tab-content"></div>
<div id="budgets" class="tab-content"></div>
`;
const dom = new JSDOM(html, { runScripts: "outside-only" });
const { document } = dom.window;
function showTab(id){
  document.querySelectorAll('.tab-content').forEach(div=>div.classList.remove('active'));
  const el=document.getElementById(id);
  if(el) el.classList.add('active');
}

document.getElementById('tab-upload').addEventListener('click', () => showTab('upload'));
document.getElementById('tab-code').addEventListener('click', () => showTab('code'));
document.getElementById('tab-budgets').addEventListener('click', () => showTab('budgets'));

function status(){
  return {
    upload: document.getElementById('upload').classList.contains('active'),
    code: document.getElementById('code').classList.contains('active'),
    budgets: document.getElementById('budgets').classList.contains('active'),
  };
}
console.log('Initial', status());
document.getElementById('tab-code').click();
console.log('After Code', status());
document.getElementById('tab-budgets').click();
console.log('After Budgets', status());
document.getElementById('tab-upload').click();
console.log('After Upload', status());
NODE`

------
https://chatgpt.com/codex/tasks/task_e_688f89f81b8c832fa1ca5071f8981a51