### PR TITLE
Add development activities section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/index.html
+++ b/index.html
@@ -959,6 +959,12 @@ function formatUK(date) {
   if (isNaN(d)) return date || '';
   return d.toLocaleDateString('en-GB', { day: '2-digit', month: 'long', year: '2-digit' });
 }
+
+function countLastMonth(dates) {
+  const cutoff = new Date();
+  cutoff.setMonth(cutoff.getMonth() - 1);
+  return dates.filter(d => new Date(d) >= cutoff).length;
+}
 function showMessage(msg) {
   const toast = document.getElementById("toast");
   toast.textContent = msg;
@@ -1769,13 +1775,14 @@ function renderStretch() {
   const table = document.createElement('table');
   table.className = 'task-table';
   const head = document.createElement('tr');
-  head.innerHTML = '<th>Task</th><th>Last Done</th><th style="min-width:200px;">Action</th>';
+  head.innerHTML = '<th>Task</th><th>Last Done</th><th>How Frequently</th><th style="min-width:200px;">Action</th>';
   table.appendChild(head);
   open.forEach(t => {
     const tr = document.createElement('tr');
     const proj = projects.find(p => p.name === t.project);
     const color = proj ? proj.color : '#000';
     const last = t.completedDates.length ? formatUK(t.completedDates[t.completedDates.length-1]) : '';
+    const freq = countLastMonth(t.completedDates);
     
     // Task cell with project underneath
     const taskCell = document.createElement('td');
@@ -1791,7 +1798,12 @@ function renderStretch() {
     taskCell.appendChild(projectName);
     
     tr.appendChild(taskCell);
-    tr.innerHTML += `<td>${last}</td>`;
+    const lastTd = document.createElement('td');
+    lastTd.textContent = last;
+    tr.appendChild(lastTd);
+    const freqTd = document.createElement('td');
+    freqTd.textContent = freq;
+    tr.appendChild(freqTd);
     
   const td = document.createElement('td');
   td.style.display = 'grid';

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "backup": "node backupMongo.js"
+    "backup": "node backupMongo.js",
+    "test": "node --test"
   },
   "dependencies": {
     "dotenv": "^17.2.1",

--- a/parenting.html
+++ b/parenting.html
@@ -16,6 +16,17 @@
     .task-table th, .task-table td { border:1px solid #e2e5e9; padding:0.5rem; text-align:left; }
     .task-table th { background:#C7BBB4; color:#2B2C29; }
     .color-swatch { display:inline-block; width:18px; height:18px; border-radius:50%; border:1px solid #999; vertical-align:middle; margin-right:6px; }
+
+    .add-toggle { background:#2B2C29; color:#C7BBB4; font-size:0.8rem; padding:0.5rem; transition:all 0.2s ease; }
+    .add-toggle:hover { background:#C7BBB4; color:#2B2C29; box-shadow:0 0 12px 2px #2B2C29; }
+    .form-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(200px,1fr)); gap:1rem; align-items:center; }
+    .form-grid label { display:flex; flex-direction:column; font-size:0.9rem; font-weight:bold; }
+    .form-grid input, .form-grid select { width:100%; font-size:1rem; padding:0.4rem; margin-top:0.3rem; box-sizing:border-box; font-weight:normal; }
+    .subtoggle { font-size:0.9rem; margin-top:0.5rem; }
+    .section-header { position:relative; }
+    .section-header .pin-star { position:absolute; top:50%; right:8px; transform:translateY(-50%); cursor:pointer; z-index:10; }
+    .section-header .pin-star svg { width:16px; height:16px; }
+    .section-header .pin-star.pinned svg { fill:#F7F6F3; stroke:#2B2C29; stroke-width:1; }
   </style>
 </head>
 <body>
@@ -24,6 +35,28 @@
   </header>
   <div id="nav-placeholder"></div>
   <script src="nav-loader.js"></script>
+
+  <section>
+    <div class="toggle section-header" onclick="toggle('developmentSection')">
+      Development Activities
+      <span class="pin-star" onclick="event.stopPropagation(); togglePin('developmentSection')" title="Pin section open">
+        <svg viewBox="0 0 24 24" fill="#2B2C29" stroke="#F7F6F3" stroke-width="1">
+          <polygon points="12,2 15.09,8.26 22,9.27 17,14.14 18.18,21.02 12,17.77 5.82,21.02 7,14.14 2,9.27 8.91,8.26"></polygon>
+        </svg>
+      </span>
+    </div>
+    <div id="developmentSection" class="hidden">
+      <div id="activityList"></div>
+      <div class="toggle add-toggle" onclick="toggle('addActivityForm')">Add Development Activity</div>
+      <div id="addActivityForm" class="hidden subtoggle form-grid">
+        <label>Name<input type="text" id="activityName"></label>
+        <label>Skill<select id="activitySkill"></select></label>
+        <div style="grid-column:1/-1;text-align:center;">
+          <button class="submit-btn" onclick="addActivity()">Submit</button>
+        </div>
+      </div>
+    </div>
+  </section>
 
   <section>
     <div class="toggle section-header" onclick="toggle('settings')">Settings</div>
@@ -96,6 +129,25 @@
       });
     }
 
+    function formatUK(date){ const d=new Date(date); if(isNaN(d)) return date||''; return d.toLocaleDateString('en-GB',{day:'2-digit',month:'long',year:'2-digit'}); }
+    function countLastMonth(dates){
+      const cutoff=new Date();
+      cutoff.setMonth(cutoff.getMonth()-1);
+      return dates.filter(d=>new Date(d)>=cutoff).length;
+    }
+
+    function updateSkillOptions(){
+      const sel=document.getElementById('activitySkill');
+      if(!sel) return;
+      sel.innerHTML='';
+      skills.filter(s=>!s.closed).forEach(s=>{
+        const opt=document.createElement('option');
+        opt.value=s.id;
+        opt.textContent=s.name;
+        sel.appendChild(opt);
+      });
+    }
+
     function hasOpenActivities(skillId){
       if(!Array.isArray(activities) || activities.length===0) return false;
       return activities.some(a => a.skillId===skillId && !a.completed);
@@ -108,6 +160,7 @@
       skills.push({ id: nextSkillId++, name, color, closed:false });
       document.getElementById('skillName').value='';
       renderSkills();
+      updateSkillOptions();
       saveParenting();
     }
 
@@ -165,9 +218,132 @@
       });
       table.appendChild(tbody);
       container.appendChild(table);
+      updateSkillOptions();
     }
 
-    async function init(){ await loadParenting(); renderSkills(); }
+    function addActivity(){
+      const name=(document.getElementById('activityName').value||'').trim();
+      const skillId=Number(document.getElementById('activitySkill').value);
+      if(!name||!skillId) return;
+      const act={id:String(nextActivityId++).padStart(8,'0'),name,skillId,completedDates:[],status:'open',dueDate:''};
+      activities.push(act);
+      document.getElementById('activityName').value='';
+      renderActivities();
+      saveParenting();
+    }
+
+    function renderActivities(){
+      const container=document.getElementById('activityList');
+      container.innerHTML='';
+      const open=activities.filter(a=>a.status==='open');
+      if(open.length===0){container.textContent='No development activities';return;}
+      const table=document.createElement('table');table.className='task-table';
+      const head=document.createElement('tr');
+      head.innerHTML='<th>Activity</th><th>Last Done</th><th>How Frequently</th><th style="min-width:200px;">Action</th>';
+      table.appendChild(head);
+      open.forEach(a=>{
+        const tr=document.createElement('tr');
+        const skill=skills.find(s=>s.id===a.skillId);
+        const color=skill?skill.color:'#000';
+        const last=a.completedDates.length?formatUK(a.completedDates[a.completedDates.length-1]):'';
+        const freq=countLastMonth(a.completedDates);
+
+        const taskCell=document.createElement('td');
+        const nameDiv=document.createElement('div');nameDiv.textContent=a.name;nameDiv.style.fontWeight='500';
+        const skillDiv=document.createElement('div');skillDiv.textContent=skill?skill.name:'';skillDiv.style.color=color;skillDiv.style.fontSize='0.8rem';skillDiv.style.marginTop='0.2rem';
+        taskCell.appendChild(nameDiv);taskCell.appendChild(skillDiv);
+        tr.appendChild(taskCell);
+
+        const lastTd=document.createElement('td');lastTd.textContent=last;tr.appendChild(lastTd);
+        const freqTd=document.createElement('td');freqTd.textContent=freq;tr.appendChild(freqTd);
+
+        const td=document.createElement('td');
+        td.style.display='grid';td.style.gridTemplateColumns='repeat(3,1fr)';td.style.gap='0.2rem';td.style.padding='0.5rem';td.style.alignItems='center';td.style.justifyItems='center';td.style.height='auto';td.style.minHeight='60px';td.style.minWidth='200px';
+
+        const addBtn=document.createElement('button');
+        addBtn.innerHTML='<svg width="18" height="18" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="10" cy="10" r="8" fill="#B5A89A"/><path d="M10 6v8M6 10h8" stroke="#fff" stroke-width="2" stroke-linecap="round"/></svg>';
+        addBtn.title='Add to Today';addBtn.style.background='none';addBtn.style.border='none';addBtn.style.cursor='pointer';addBtn.style.padding='2px';
+        addBtn.onclick=()=>addActivityToToday(a.id,a.name);
+
+        const logBtn=document.createElement('button');
+        logBtn.innerHTML='<svg width="18" height="18" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="10" cy="10" r="8" fill="#81B29A"/><path d="m6 10 2 2 6-6" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+        logBtn.title='Log Completion';logBtn.style.background='none';logBtn.style.border='none';logBtn.style.cursor='pointer';logBtn.style.padding='2px';
+        logBtn.onclick=()=>logActivity(a.id);
+
+        const editBtn=document.createElement('button');
+        editBtn.innerHTML='<svg width="18" height="18" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="3" y="4" width="14" height="12" rx="2" fill="#B5A89A"/><path d="m6 2v4m8-4v4" stroke="#2B2C29" stroke-width="2" stroke-linecap="round"/><path d="M3 8h14" stroke="#2B2C29" stroke-width="2"/><circle cx="8" cy="12" r="1" fill="#2B2C29"/><circle cx="12" cy="12" r="1" fill="#2B2C29"/></svg>';
+        editBtn.title='Edit Due Date';editBtn.style.background='none';editBtn.style.border='none';editBtn.style.cursor='pointer';editBtn.style.padding='2px';
+        editBtn.onclick=()=>editActivityDue(a.id);
+
+        const archiveBtn=document.createElement('button');
+        archiveBtn.innerHTML='<svg width="18" height="18" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="3" y="4" width="14" height="3" rx="2" fill="#B5A89A"/><rect x="5" y="8" width="10" height="8" rx="2" fill="#C7BBB4"/><rect x="8" y="11" width="4" height="2" rx="1" fill="#2B2C29"/></svg>';
+        archiveBtn.title='Archive';archiveBtn.style.background='none';archiveBtn.style.border='none';archiveBtn.style.cursor='pointer';archiveBtn.style.padding='2px';
+        archiveBtn.onclick=()=>confirmArchiveActivity(a.id,a.name);
+
+        const delBtn=document.createElement('button');
+        delBtn.innerHTML='<svg width="18" height="18" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="6" y="8" width="8" height="8" rx="2" fill="#E07A5F"/><rect x="9" y="11" width="2" height="3" rx="1" fill="#fff"/><rect x="8" y="4" width="4" height="2" rx="1" fill="#2B2C29"/></svg>';
+        delBtn.title='Delete';delBtn.style.background='none';delBtn.style.border='none';delBtn.style.cursor='pointer';delBtn.style.padding='2px';
+        delBtn.onclick=()=>confirmDeleteActivity(a.id,a.name);
+
+        td.appendChild(addBtn);
+        td.appendChild(logBtn);
+        td.appendChild(editBtn);
+        td.appendChild(archiveBtn);
+        td.appendChild(delBtn);
+        tr.appendChild(td);
+        table.appendChild(tr);
+      });
+      container.appendChild(table);
+    }
+
+    function logActivity(id){
+      const act=activities.find(a=>a.id===id);
+      if(!act) return;
+      act.completedDates.push(new Date().toISOString().slice(0,10));
+      saveParenting();
+      renderActivities();
+    }
+
+    function editActivityDue(id){
+      const act=activities.find(a=>a.id===id);
+      if(!act) return;
+      const newDue=prompt('Enter new due date (YYYY-MM-DD):', act.dueDate||'');
+      if(newDue!==null){act.dueDate=newDue; saveParenting(); renderActivities();}
+    }
+
+    function confirmArchiveActivity(id,name){ if(!confirm(`Are you sure you want to archive the activity "${name}"?`)) return; archiveActivity(id); }
+    function archiveActivity(id){ const act=activities.find(a=>a.id===id); if(!act) return; act.status='closed'; act.closedDate=new Date().toISOString().slice(0,10); saveParenting(); renderActivities(); }
+    function confirmDeleteActivity(id,name){ if(!confirm(`Are you sure you want to delete the activity "${name}"? This action cannot be undone.`)) return; deleteActivity(id); }
+    function deleteActivity(id){ activities=activities.filter(a=>a.id!==id); saveParenting(); renderActivities(); }
+
+    async function addActivityToToday(id,name){
+      await fetch('/api/add-to-today',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({taskType:'dev',taskId:id,taskName:name})});
+    }
+
+    function togglePin(sectionId){
+      const star=document.querySelector(`[onclick*="togglePin('${sectionId}')"]`);
+      const pinned=!star.classList.contains('pinned');
+      star.classList.toggle('pinned');
+      let pins=JSON.parse(localStorage.getItem('parentingPins')||'[]');
+      if(pinned){
+        pins.push(sectionId);
+        const sec=document.getElementById(sectionId); if(sec) sec.classList.remove('hidden');
+      } else {
+        pins=pins.filter(id=>id!==sectionId);
+      }
+      localStorage.setItem('parentingPins',JSON.stringify(pins));
+    }
+
+    function restorePins(){
+      const pins=JSON.parse(localStorage.getItem('parentingPins')||'[]');
+      pins.forEach(id=>{
+        const star=document.querySelector(`[onclick*="togglePin('${id}')"]`);
+        if(star) star.classList.add('pinned');
+        const sec=document.getElementById(id); if(sec) sec.classList.remove('hidden');
+      });
+    }
+
+    async function init(){ await loadParenting(); renderSkills(); renderActivities(); restorePins(); }
     document.addEventListener('DOMContentLoaded', init);
   </script>
 </body>

--- a/server.js
+++ b/server.js
@@ -294,7 +294,11 @@ app.get('/api/finance-export', (req, res) => {
   res.send(buf);
 });
 
-initDb();
-app.listen(PORT, () => {
-  console.log(`Server running on http://localhost:${PORT} (data dir: ${DATA_DIR})`);
-});
+if (require.main === module) {
+  initDb();
+  app.listen(PORT, () => {
+    console.log(`Server running on http://localhost:${PORT} (data dir: ${DATA_DIR})`);
+  });
+}
+
+module.exports = { app, initDb };

--- a/server.test.js
+++ b/server.test.js
@@ -1,0 +1,16 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { app, initDb } = require('./server');
+
+test('GET /shopping returns HTML', async (t) => {
+  initDb();
+  const server = app.listen(0);
+  t.after(() => server.close());
+  const port = server.address().port;
+  const res = await fetch(`http://localhost:${port}/shopping`);
+  assert.strictEqual(res.status, 200);
+  const text = await res.text();
+  assert.ok(text.includes('<title>Shopping</title>'));
+});
+

--- a/today.html
+++ b/today.html
@@ -80,6 +80,8 @@ body { margin: 0; padding: 0; }
     <ul id="bigTaskList" class="task-list hidden"></ul>
     <label style="display:block;margin-top:0.5rem;"><input type="checkbox" id="diyBigToggle"> Show DIY Big Tasks</label>
     <ul id="diyBigTaskList" class="task-list hidden"></ul>
+    <label style="display:block;margin-top:0.5rem;"><input type="checkbox" id="devToggle"> Show Development Activities</label>
+    <ul id="devTaskList" class="task-list hidden"></ul>
   </div>
   <div id="main">
     <!-- This can be used for additional content later -->
@@ -204,7 +206,7 @@ body { margin: 0; padding: 0; }
 </div>
 
 <script>
-let projects=[], weeklyTasks=[], oneOffTasks=[], recurringTasks=[], stretchTasks=[], bigTasks=[], deletedTasks=[], shoppingList=[], longTermList=[], generalList=[];
+let projects=[], weeklyTasks=[], oneOffTasks=[], recurringTasks=[], stretchTasks=[], bigTasks=[], deletedTasks=[], shoppingList=[], longTermList=[], generalList=[], parentingSkills=[], parentingActivities=[], parentingNextSkillId=1, parentingNextActivityId=1;
 let todayList=[], todayTasks=[], todayQuickHistory=[];
 // Removed Overdue/Due Soon lists
 let nextId=1;
@@ -280,6 +282,14 @@ async function loadData(){
       diyBigTasks=diyDataStore.diyBigTasks||[];
       diyCalendar=diyDataStore.calendarEvents||[];
     }
+    const resP=await fetch('/api/parenting-data');
+    if(resP.ok){
+      const pd=await resP.json();
+      parentingSkills=pd.skills||[];
+      parentingActivities=pd.activities||[];
+      parentingNextSkillId=pd.nextSkillId||1;
+      parentingNextActivityId=pd.nextActivityId||1;
+    }
   }catch(e){console.error('Failed to load data',e);}
 }
 async function saveData(){const data={projects,weeklyTasks,oneOffTasks,recurringTasks,stretchTasks,bigTasks,deletedTasks,shoppingList,longTermList,generalList,todayList,nextId,todayQuickHistory};try{await fetch('/api/index-data',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}catch(e){console.error('Failed to save data',e);}}
@@ -295,6 +305,10 @@ async function saveDiyData(){
   try{
     await fetch('/api/diy-data',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(diyDataStore)});
   }catch(e){console.error('Failed to save diy data',e);}
+}
+async function saveParentingData(){
+  const data={skills:parentingSkills,activities:parentingActivities,nextSkillId:parentingNextSkillId,nextActivityId:parentingNextActivityId};
+  try{await fetch('/api/parenting-data',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}catch(e){console.error('Failed to save parenting data',e);}
 }
 // Removed categorize/overdue logic
 function rebuildToday(){
@@ -313,6 +327,7 @@ function rebuildToday(){
     else if(r.type==='stretch') arr=stretchTasks;
     else if(r.type==='big') arr=bigTasks;
     else if(r.type==='diybig') arr=diyBigTasks;
+    else if(r.type==='dev') arr=parentingActivities;
     let task=null, depth=0;
     if(r.type==='work'){
       const info=getWorkTaskInfo(r.id);
@@ -339,6 +354,9 @@ function rebuildToday(){
     } else if(r.type==='diybig'){
       todayTasks.push({category:'diybig',type:'diybig',item:task});
       return;
+    } else if(r.type==='dev'){
+      todayTasks.push({category:'dev',type:'dev',item:task});
+      return;
     }
   // No overdue/due buckets anymore; just push a simple today item
   todayTasks.push({category:'today',type:r.type,item:task});
@@ -350,6 +368,7 @@ function renderSide(){
   if(document.getElementById('stretchToggle').checked) renderStretchTasks();
   if(document.getElementById('bigToggle').checked) renderBigTasks();
   if(document.getElementById('diyBigToggle').checked) renderDiyBigTasks();
+  if(document.getElementById('devToggle').checked) renderDevTasks();
 }
 function renderWorkTasks(){
   const ul=document.getElementById('workTaskList');
@@ -420,15 +439,42 @@ function renderDiyBigTasks(){
     ul.appendChild(li);
   });
 }
+
+function renderDevTasks(){
+  const ul=document.getElementById('devTaskList');
+  ul.innerHTML='';
+  parentingActivities.filter(a=>a.status==='open').forEach(a=>{
+    const skill=parentingSkills.find(s=>s.id===a.skillId);
+    const li=document.createElement('li');
+    li.textContent=`[Parenting - dev] ${a.name} (${skill?skill.name:''})`;
+    const b=document.createElement('button');
+    b.textContent='Add';
+    b.onclick=()=>addDevToToday(a.id);
+    li.appendChild(b);
+    ul.appendChild(li);
+  });
+}
+
+function addDevToToday(id){
+  const task=parentingActivities.find(a=>a.id===id);
+  if(!task) return;
+  todayTasks.push({category:'dev',type:'dev',item:task});
+  todayList.push({type:'dev',id});
+  saveData();
+  saveParentingData();
+  renderToday();
+}
 function updateToggles(){
   const wt=document.getElementById('workToggle');
   const dt=document.getElementById('diyToggle');
   const bt=document.getElementById('bigToggle');
   const db=document.getElementById('diyBigToggle');
+  const dv=document.getElementById('devToggle');
   document.getElementById('workTaskList').classList.toggle('hidden', !wt.checked);
   document.getElementById('diyTaskList').classList.toggle('hidden', !dt.checked);
   document.getElementById('bigTaskList').classList.toggle('hidden', !bt.checked);
   document.getElementById('diyBigTaskList').classList.toggle('hidden', !db.checked);
+  document.getElementById('devTaskList').classList.toggle('hidden', !dv.checked);
 }
 function renderToday(){
   const ul=document.getElementById('todayList');
@@ -447,7 +493,15 @@ function renderToday(){
       if(['oneoff','recurring','weekly','stretch','big'].includes(t.type)) page='Todo';
       else if(t.type==='work') page='Work';
       else if(t.type==='diy' || t.type==='diybig') page='DIY';
-      label=`${t.item.name} (${t.item.project})`;
+      else if(t.type==='dev') page='Parenting';
+      let projectText='';
+      if(t.type==='dev'){
+        const skill=parentingSkills.find(s=>s.id===t.item.skillId);
+        projectText=skill?skill.name:'';
+      }else{
+        projectText=t.item.project;
+      }
+      label=`${t.item.name} (${projectText})`;
       if(t.type==='big' || t.type==='diybig') label='[BIG] '+label;
       let info='';
       if(page==='Todo'){info=t.type;}
@@ -611,6 +665,9 @@ function completeToday(idx){
   }else if(t.type==='diybig'){
     t.item.status='closed';
     saveDiyData();
+  }else if(t.type==='dev'){
+    t.item.completedDates.push(formatISO(now));
+    saveParentingData();
   }
   // Overdue/Due categories removed
   saveData();
@@ -640,6 +697,11 @@ document.getElementById('bigToggle').addEventListener('change',e=>{
 document.getElementById('diyBigToggle').addEventListener('change',e=>{
   document.getElementById('diyBigTaskList').classList.toggle('hidden',!e.target.checked);
   if(e.target.checked) renderDiyBigTasks();
+  updateToggles();
+});
+document.getElementById('devToggle').addEventListener('change',e=>{
+  document.getElementById('devTaskList').classList.toggle('hidden',!e.target.checked);
+  if(e.target.checked) renderDevTasks();
   updateToggles();
 });
 


### PR DESCRIPTION
## Summary
- Add Development Activities section to parenting page with pinable banner, task table, and add form
- Track past month completion frequency for stretch tasks and development activities
- Integrate development activities into Today view and allow adding to daily list
- Export express app and add basic server test with npm test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6e93489a8832f853aac9d3bafbb08