### PR TITLE
Style soul banners and persist journal media

### DIFF
--- a/server.js
+++ b/server.js
@@ -110,6 +110,14 @@ function initDb() {
   financeData = loadJson(FINANCE_FILE, financeData);
   parentingData = loadJson(PARENTING_FILE, parentingData);
   soulData = loadJson(SOUL_FILE, soulData);
+  soulData.meditations = soulData.meditations || [];
+  soulData.nextMeditationId = soulData.nextMeditationId || 1;
+  soulData.journalTypes = soulData.journalTypes || [];
+  soulData.nextJournalTypeId = soulData.nextJournalTypeId || 1;
+    soulData.journals = (soulData.journals || []).map(j=>({ ...j, media: j.media || [] }));
+  soulData.nextJournalId = soulData.nextJournalId || 1;
+  soulData.mottos = soulData.mottos || [];
+  soulData.nextMottoId = soulData.nextMottoId || 1;
   financeData.pots = financeData.pots || [];
   financeData.nextPotId = financeData.nextPotId || 1;
 }
@@ -239,20 +247,27 @@ app.post('/api/parenting-data', (req, res) => {
 });
 
 // soul page data
-let soulData = {
-  projects: [],
-  nextProjectId: 1
-};
+  let soulData = {
+    meditations: [],
+    nextMeditationId: 1,
+    journalTypes: [],
+    nextJournalTypeId: 1,
+    journals: [], // each {id,title,date,type,text,media:[]}
+    nextJournalId: 1,
+    mottos: [],
+    nextMottoId: 1
+  };
 
 app.get('/api/soul-data', (req, res) => {
   res.json(soulData);
 });
 
-app.post('/api/soul-data', (req, res) => {
-  soulData = req.body;
-  fs.writeFileSync(SOUL_FILE, JSON.stringify(soulData, null, 2));
-  res.json({ status: 'ok' });
-});
+  app.post('/api/soul-data', (req, res) => {
+    soulData = req.body;
+    soulData.journals = (soulData.journals || []).map(j=>({ ...j, media: j.media || [] }));
+    fs.writeFileSync(SOUL_FILE, JSON.stringify(soulData, null, 2));
+    res.json({ status: 'ok' });
+  });
 
 app.post('/api/add-to-today', (req, res) => {
   const { taskType, taskId, taskName } = req.body;

--- a/soul.html
+++ b/soul.html
@@ -3,50 +3,41 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Soul Activities</title>
+<title>Soul</title>
 <link rel="stylesheet" href="styles.css">
 <style>
-body { margin:0; padding:0; }
 section { padding:1rem; }
 .hidden { display:none !important; }
+.form-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(200px,1fr)); gap:1rem; align-items:center; }
+.form-grid label { display:flex; flex-direction:column; font-size:0.9rem; font-weight:bold; }
+.form-grid input, .form-grid select, .form-grid textarea { width:100%; font-size:1rem; padding:0.4rem; margin-top:0.3rem; box-sizing:border-box; font-weight:normal; }
+.item-grid { display:flex; flex-wrap:wrap; gap:1rem; margin-top:1rem; }
+.meditation-item, .journal-item, .motto-item { padding:1rem; border-radius:var(--radius-sm); position:relative; min-width:150px; min-height:100px; box-shadow:0 1px 2px rgba(0,0,0,0.1); background:var(--color-surface); cursor:pointer; }
+.meditation-item .info-btn, .journal-item .info-btn, .motto-item .info-btn { position:absolute; bottom:4px; right:4px; background:none; border:none; cursor:pointer; color:var(--color-text); }
+.meditation-item .play-btn { position:absolute; top:4px; right:4px; background:none; border:none; cursor:pointer; }
+.filter-grid { display:grid; grid-template-columns: repeat(auto-fill,minmax(150px,1fr)); gap:0.5rem; margin:1rem 0; }
+.modal { position:fixed; z-index:1000; left:0; top:0; width:100%; height:100%; background:rgba(43,44,41,0.5); display:flex; align-items:center; justify-content:center; }
+.modal-content { background: var(--color-surface); border-radius:8px; padding:1rem; width:90%; max-width:500px; }
+.modal-header { display:flex; justify-content:space-between; align-items:center; margin-bottom:1rem; }
+.modal-body { margin-bottom:1rem; }
+.audio-controls { display:flex; align-items:center; gap:0.5rem; margin-top:0.5rem; }
+.audio-controls button { background:#2B2C29; color:#fff; border:none; padding:0.3rem 0.6rem; border-radius:4px; cursor:pointer; }
+.audio-controls input[type=range]{ flex:1; }
 </style>
 </head>
 <body>
 <header>
-  <h1>Soul Activities</h1>
+  <h1>Soul</h1>
 </header>
 <div id="nav-placeholder"></div>
 <script src="nav-loader.js"></script>
-
-<!-- Settings Section -->
-<section>
-  <div class="toggle section-header" onclick="toggle('settings')">
-    Settings
-    <span class="pin-star" onclick="event.stopPropagation();togglePin('settings')">
-      <svg viewBox="0 0 20 20" fill="none" stroke="#2B2C29" stroke-width="1.5"><polygon points="10,2 12.5,7.5 18,8 14,12 15,18 10,15 5,18 6,12 2,8 7.5,7.5"/></svg>
-    </span>
-  </div>
-  <div id="settings" class="hidden">
-    <div class="toggle add-toggle" onclick="toggle('addProjectForm')">Add Project</div>
-    <div id="addProjectForm" class="hidden subtoggle form-grid">
-      <label>Project Name<input type="text" id="projectName" placeholder="e.g. Meditation"></label>
-      <label>Color<input type="color" id="projectColor" value="#81B29A"></label>
-      <div style="grid-column:1/-1;text-align:center;">
-        <button class="submit-btn" onclick="addProject()">Add</button>
-      </div>
-    </div>
-    <div id="projectsTable"></div>
-  </div>
-</section>
 
 <!-- Meditation Section -->
 <section>
   <div class="toggle section-header" onclick="toggle('meditationSection')">
     Meditation
-    <span class="pin-star" onclick="event.stopPropagation();togglePin('meditationSection')">
-      <svg viewBox="0 0 20 20" fill="none" stroke="#2B2C29" stroke-width="1.5">
-        <polygon points="10,2 12.5,7.5 18,8 14,12 15,18 10,15 5,18 6,12 2,8 7.5,7.5"/>
-      </svg>
+    <span class="pin-star" onclick="event.stopPropagation(); togglePin('meditationSection')" title="Pin section open">
+      <svg viewBox="0 0 20 20" fill="none" stroke="#2B2C29" stroke-width="1.5"><polygon points="10,2 12.5,7.5 18,8 14,12 15,18 10,15 5,18 6,12 2,8 7.5,7.5"/></svg>
     </span>
   </div>
   <div id="meditationSection" class="hidden">
@@ -54,63 +45,353 @@ section { padding:1rem; }
     <div id="addMeditationForm" class="hidden subtoggle form-grid">
       <label>Name<input type="text" id="meditationName"></label>
       <label>Description<textarea id="meditationDesc"></textarea></label>
-      <label>Upload Audio<input type="file" id="meditationAudio" accept="audio/*"></label>
+      <label>Colour<input type="color" id="meditationColor" value="#81B29A"></label>
+      <label>Audio<input type="file" id="meditationAudio" accept="audio/*"></label>
       <div style="grid-column:1/-1;text-align:center;">
         <button class="submit-btn" onclick="addMeditation()">Submit</button>
       </div>
     </div>
-    <div id="meditationTable"></div>
-    <div class="toggle add-toggle" onclick="toggle('archivedMeditationSection')">View Archived Meditations</div>
-    <div id="archivedMeditationSection" class="hidden">
-      <div id="archivedMeditationTable"></div>
-    </div>
+    <div id="meditationList" class="item-grid"></div>
   </div>
 </section>
 
-<!-- More soul sections can be added here using the same format -->
+<!-- Journal Section -->
+<section>
+  <div class="toggle section-header" onclick="toggle('journalSection')">
+    Journal
+    <span class="pin-star" onclick="event.stopPropagation(); togglePin('journalSection')" title="Pin section open">
+      <svg viewBox="0 0 20 20" fill="none" stroke="#2B2C29" stroke-width="1.5"><polygon points="10,2 12.5,7.5 18,8 14,12 15,18 10,15 5,18 6,12 2,8 7.5,7.5"/></svg>
+    </span>
+  </div>
+  <div id="journalSection" class="hidden">
+    <div id="addJournalForm" class="form-grid">
+      <label>Title<input type="text" id="journalTitle"></label>
+      <label>Date<input type="date" id="journalDate"></label>
+      <label>Type<select id="journalTypeSelect"></select></label>
+      <label>Text<textarea id="journalText"></textarea></label>
+      <label>Media<input type="file" id="journalMedia" accept="image/*,video/*,audio/*" multiple></label>
+      <div style="grid-column:1/-1;text-align:center;">
+        <button class="submit-btn" onclick="addJournal()">Submit</button>
+      </div>
+    </div>
+    <div class="filter-grid">
+      <label>Name<input type="text" id="filterJournalName"></label>
+      <label>Start Date<input type="date" id="filterJournalStart"></label>
+      <label>End Date<input type="date" id="filterJournalEnd"></label>
+      <label>Type<select id="filterJournalType"></select></label>
+      <div style="grid-column:1/-1;text-align:right;"><button class="filter-apply-btn" onclick="renderJournals()">Apply Filters</button></div>
+    </div>
+    <div class="toggle add-toggle" onclick="toggle('addJournalTypeForm')">Add Journal Entry Type</div>
+    <div id="addJournalTypeForm" class="hidden subtoggle form-grid">
+      <label>Name<input type="text" id="journalTypeName"></label>
+      <label>Colour<input type="color" id="journalTypeColor" value="#81B29A"></label>
+      <div style="grid-column:1/-1;text-align:center;">
+        <button class="submit-btn" onclick="addJournalType()">Add Type</button>
+      </div>
+    </div>
+    <div id="journalList" class="item-grid"></div>
+  </div>
+</section>
+
+<!-- Mottos/Affirmations Section -->
+<section>
+  <div class="toggle section-header" onclick="toggle('mottoSection')">
+    Motto's/Affirmations
+    <span class="pin-star" onclick="event.stopPropagation(); togglePin('mottoSection')" title="Pin section open">
+      <svg viewBox="0 0 20 20" fill="none" stroke="#2B2C29" stroke-width="1.5"><polygon points="10,2 12.5,7.5 18,8 14,12 15,18 10,15 5,18 6,12 2,8 7.5,7.5"/></svg>
+    </span>
+  </div>
+  <div id="mottoSection" class="hidden">
+    <div class="toggle add-toggle" onclick="toggle('addMottoForm')">Add Motto/Affirmation</div>
+    <div id="addMottoForm" class="hidden subtoggle form-grid">
+      <label>Name<input type="text" id="mottoName"></label>
+      <label>Text<textarea id="mottoText"></textarea></label>
+      <div style="grid-column:1/-1;text-align:center;">
+        <button class="submit-btn" onclick="addMotto()">Submit</button>
+      </div>
+    </div>
+    <div id="mottoList" class="item-grid"></div>
+  </div>
+</section>
+
+<div id="modalContainer" class="hidden"></div>
 
 <script>
-function toggle(id){ const el=document.getElementById(id); if(el) el.classList.toggle('hidden'); }
-function togglePin(id){ const header=document.querySelector(`[onclick*="toggle('${id}')"]`); const star=header?header.querySelector('.pin-star'):null; if(star) star.classList.toggle('pinned'); }
+let pinnedSections = [];
+let meditations = [];
+let nextMeditationId = 1;
+let journalTypes = [];
+let nextJournalTypeId = 1;
+let journals = [];
+let nextJournalId = 1;
+let mottos = [];
+let nextMottoId = 1;
 
-let projects=[]; let nextProjectId=1;
+function toggle(id){ const el=document.getElementById(id); if(el) el.classList.toggle('hidden'); }
+
+function togglePin(sectionId){
+  const index = pinnedSections.indexOf(sectionId);
+  const star = document.querySelector(`[onclick*="togglePin('${sectionId}')"]`);
+  if(index === -1){
+    pinnedSections.push(sectionId);
+    star.classList.add('pinned');
+    star.title='Unpin section';
+  }else{
+    pinnedSections.splice(index,1);
+    star.classList.remove('pinned');
+    star.title='Pin section open';
+  }
+  localStorage.setItem('soulPinned', JSON.stringify(pinnedSections));
+}
+
+function loadPinnedSections(){
+  const saved = localStorage.getItem('soulPinned');
+  if(saved){
+    pinnedSections = JSON.parse(saved);
+    pinnedSections.forEach(id=>{
+      const el=document.getElementById(id);
+      const star=document.querySelector(`[onclick*="togglePin('${id}')"]`);
+      if(el && star){ el.classList.remove('hidden'); star.classList.add('pinned'); star.title='Unpin section'; }
+    });
+  }
+}
 
 async function loadSoul(){
-  try{ const res=await fetch('/api/soul-data'); if(res.ok){ const d=await res.json(); projects=d.projects||[]; nextProjectId=d.nextProjectId||1; } }catch(e){ }
+  try{
+    const res = await fetch('/api/soul-data');
+    if(res.ok){
+      const d = await res.json();
+      meditations = d.meditations || [];
+      nextMeditationId = d.nextMeditationId || 1;
+      journalTypes = d.journalTypes || [];
+      nextJournalTypeId = d.nextJournalTypeId || 1;
+        journals = (d.journals || []).map(j=>({ ...j, media: j.media || [] }));
+      nextJournalId = d.nextJournalId || 1;
+      mottos = d.mottos || [];
+      nextMottoId = d.nextMottoId || 1;
+    }
+  }catch(e){}
 }
-async function saveSoul(){ const payload={projects,nextProjectId}; await fetch('/api/soul-data',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)}); }
 
-function addProject(){
-  const nameEl=document.getElementById('projectName'); const colorEl=document.getElementById('projectColor');
-  const name=(nameEl.value||'').trim(); if(!name){ nameEl.focus(); return; }
-  const color=colorEl.value||'#81B29A';
-  projects.push({ id:String(nextProjectId++).padStart(5,'0'), name, color, closed:false });
-  nameEl.value='';
-  renderProjects();
+async function saveSoul(){
+  const payload = {meditations,nextMeditationId,journalTypes,nextJournalTypeId,journals,nextJournalId,mottos,nextMottoId};
+  await fetch('/api/soul-data',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
+}
+
+/* Meditation functions */
+function addMeditation(){
+  const name=document.getElementById('meditationName').value.trim();
+  const desc=document.getElementById('meditationDesc').value.trim();
+  const color=document.getElementById('meditationColor').value;
+  const file=document.getElementById('meditationAudio').files[0];
+  if(!name || !file) return;
+  const reader=new FileReader();
+  reader.onload=function(){
+    meditations.push({id:nextMeditationId++,name,desc,color,audio:reader.result});
+    document.getElementById('meditationName').value='';
+    document.getElementById('meditationDesc').value='';
+    document.getElementById('meditationAudio').value='';
+    renderMeditations();
+    saveSoul();
+  };
+  reader.readAsDataURL(file);
+}
+
+function renderMeditations(){
+  const container=document.getElementById('meditationList');
+  if(!meditations.length){ container.innerHTML='<p style="opacity:.7">No meditations yet.</p>'; return;}
+  container.innerHTML=meditations.map(m=>`<div class=\"meditation-item\" style=\"background:${m.color}\" onclick=\"playMeditation(${m.id})\"><strong>${m.name}</strong><button class=\"info-btn\" onclick=\"event.stopPropagation();editMeditation(${m.id})\">ℹ️</button></div>`).join('');
+}
+
+function playMeditation(id){
+  const m=meditations.find(x=>x.id===id); if(!m) return;
+  const modal=document.getElementById('modalContainer');
+  modal.innerHTML=`<div class=\"modal\"><div class=\"modal-content\"><div class=\"modal-header\"><h3>${m.name}</h3><span class=\"close\" onclick=\"closeModal()\">&times;</span></div><div class=\"modal-body\"><audio id=\"audioPlayer\" src=\"${m.audio}\"></audio><div class=\"audio-controls\"><button id=\"rewindBtn\">-30s</button><button id=\"playPauseBtn\">Play</button><button id=\"forwardBtn\">+30s</button><input type=\"range\" id=\"seekBar\" min=\"0\" max=\"100\" value=\"0\"><button id=\"speedBtn\">1x</button></div></div></div></div>`;
+  modal.classList.remove('hidden');
+  initAudioPlayer();
+}
+
+function initAudioPlayer(){
+  const audio=document.getElementById('audioPlayer');
+  const playPause=document.getElementById('playPauseBtn');
+  const seek=document.getElementById('seekBar');
+  const rewind=document.getElementById('rewindBtn');
+  const forward=document.getElementById('forwardBtn');
+  const speed=document.getElementById('speedBtn');
+  const speeds=[0.5,1,1.5,2];
+  playPause.onclick=()=>{ if(audio.paused){ audio.play(); playPause.textContent='Pause'; } else { audio.pause(); playPause.textContent='Play'; } };
+  audio.addEventListener('timeupdate',()=>{ if(audio.duration) seek.value=(audio.currentTime/audio.duration)*100; });
+  seek.oninput=()=>{ if(audio.duration) audio.currentTime=(seek.value/100)*audio.duration; };
+  rewind.onclick=()=>{ audio.currentTime=Math.max(0,audio.currentTime-30); };
+  forward.onclick=()=>{ audio.currentTime=Math.min(audio.duration||0,audio.currentTime+30); };
+  speed.onclick=()=>{ let idx=speeds.indexOf(audio.playbackRate); idx=(idx+1)%speeds.length; audio.playbackRate=speeds[idx]; speed.textContent=speeds[idx]+"x"; };
+}
+
+function editMeditation(id){
+  const m=meditations.find(x=>x.id===id); if(!m) return;
+  const modal=document.getElementById('modalContainer');
+  modal.innerHTML=`<div class=\"modal\"><div class=\"modal-content\"><div class=\"modal-header\"><h3>Edit ${m.name}</h3><span class=\"close\" onclick=\"closeModal()\">&times;</span></div><div class=\"modal-body form-grid\"><label>Name<input id=\"editMedName\" value=\"${m.name}\"></label><label>Description<textarea id=\"editMedDesc\">${m.desc}</textarea></label><label>Colour<input type=\"color\" id=\"editMedColor\" value=\"${m.color}\"></label><div style=\"grid-column:1/-1;text-align:right\"><button class=\"btn\" onclick=\"updateMeditation(${m.id})\">Save</button><button class=\"btn\" style=\"margin-left:0.5rem\" onclick=\"deleteMeditation(${m.id})\">Delete</button></div></div></div></div>`;
+  modal.classList.remove('hidden');
+}
+
+function updateMeditation(id){
+  const m=meditations.find(x=>x.id===id); if(!m) return;
+  m.name=document.getElementById('editMedName').value.trim();
+  m.desc=document.getElementById('editMedDesc').value.trim();
+  m.color=document.getElementById('editMedColor').value;
+  renderMeditations();
+  saveSoul();
+  closeModal();
+}
+
+function deleteMeditation(id){
+  meditations=meditations.filter(x=>x.id!==id);
+  renderMeditations();
+  saveSoul();
+  closeModal();
+}
+
+/* Journal functions */
+function addJournalType(){
+  const name=document.getElementById('journalTypeName').value.trim();
+  const color=document.getElementById('journalTypeColor').value;
+  if(!name) return;
+  journalTypes.push({id:nextJournalTypeId++,name,color});
+  document.getElementById('journalTypeName').value='';
+  renderJournalTypeOptions();
   saveSoul();
 }
 
-function toggleClosed(id){ const p=projects.find(x=>x.id===id); if(!p) return; p.closed=!p.closed; renderProjects(); saveSoul(); }
-function deleteProject(id){ projects=projects.filter(p=>p.id!==id); renderProjects(); saveSoul(); }
-
-function renderProjects(){
-  const container=document.getElementById('projectsTable');
-  if(!projects.length){ container.innerHTML='<p style="opacity:.7">No projects yet.</p>'; return; }
-  const head=`<div class="task-row grid-header" style="display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:.25rem;align-items:center;font-weight:600;">
-    <div>Project</div><div>Status</div><div>Colour</div><div>Actions</div></div>`;
-  const rows=projects.map(p=>`<div class="task-row" style="display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:.25rem;align-items:center;border:1px solid #ccc;padding:.25rem;margin-top:.25rem;background:var(--color-surface)">
-    <div>${p.name}</div>
-    <div>${p.closed? 'Closed':'Active'}</div>
-    <div><span title="${p.color}" style="display:inline-block;width:18px;height:18px;border-radius:50%;border:1px solid #aaa;background:${p.color}"></span></div>
-    <div>
-      <button class="btn" onclick="toggleClosed('${p.id}')">${p.closed? 'Open':'Close'}</button>
-      <button class="btn" onclick="deleteProject('${p.id}')">Delete</button>
-    </div>
-  </div>`).join('');
-  container.innerHTML=head+rows;
+function renderJournalTypeOptions(){
+  const selects=[document.getElementById('journalTypeSelect'), document.getElementById('filterJournalType')];
+  selects.forEach(sel=>{ sel.innerHTML='<option value="">--Type--</option>'+journalTypes.map(t=>`<option value="${t.id}">${t.name}</option>`).join(''); });
 }
 
-async function init(){ await loadSoul(); renderProjects(); }
+  function addJournal(){
+    const title=document.getElementById('journalTitle').value.trim();
+    const date=document.getElementById('journalDate').value;
+    const type=document.getElementById('journalTypeSelect').value;
+    const text=document.getElementById('journalText').value.trim();
+    const files=Array.from(document.getElementById('journalMedia').files);
+    if(!title || !date || !type) return;
+    const readers=files.map(f=>new Promise(res=>{const r=new FileReader();r.onload=()=>res(r.result);r.readAsDataURL(f);}));
+    Promise.all(readers).then(media=>{
+      journals.push({id:nextJournalId++,title,date,type,text,media});
+      document.getElementById('journalTitle').value='';
+      document.getElementById('journalDate').value='';
+      document.getElementById('journalText').value='';
+      document.getElementById('journalMedia').value='';
+      renderJournals();
+      saveSoul();
+    });
+  }
+
+function renderJournals(){
+  const container=document.getElementById('journalList');
+  if(!journals.length){ container.innerHTML='<p style="opacity:.7">No journal entries.</p>'; return;}
+  const nameFilter=document.getElementById('filterJournalName').value.toLowerCase();
+  const start=document.getElementById('filterJournalStart').value;
+  const end=document.getElementById('filterJournalEnd').value;
+  const type=document.getElementById('filterJournalType').value;
+  let list=journals.slice();
+  if(nameFilter) list=list.filter(j=>j.title.toLowerCase().includes(nameFilter));
+  if(start) list=list.filter(j=>j.date>=start);
+  if(end) list=list.filter(j=>j.date<=end);
+  if(type) list=list.filter(j=>j.type===type);
+  if(!list.length){ container.innerHTML='<p style="opacity:.7">No journal entries match.</p>'; return;}
+    container.innerHTML=list.map(j=>{ const t=journalTypes.find(x=>x.id===j.type); const color=t?t.color:'#fff'; const mediaThumbs=(j.media||[]).map(m=>m.startsWith('data:image')?`<img src=\"${m}\" style=\"width:40px;height:40px;object-fit:cover;margin-right:4px\">`:`<a href=\"${m}\" target=\"_blank\" onclick=\"event.stopPropagation()\" style=\"margin-right:4px\">file</a>`).join(''); return `<div class=\"journal-item\" style=\"background:${color}\" onclick=\"viewJournal(${j.id})\"><strong>${j.date}</strong><div>${j.title}</div><div>${mediaThumbs}</div></div>`; }).join('');
+  }
+
+function viewJournal(id){
+  const j=journals.find(x=>x.id===id); if(!j) return;
+  const t=journalTypes.find(x=>x.id===j.type);
+  const modal=document.getElementById('modalContainer');
+    const mediaHtml=(j.media||[]).map(m=>{
+      if(m.startsWith('data:image')) return `<img src="${m}" style="max-width:100%;margin-top:0.5rem;">`;
+      if(m.startsWith('data:video')) return `<video controls src="${m}" style="width:100%;margin-top:0.5rem;"></video>`;
+      if(m.startsWith('data:audio')) return `<audio controls src="${m}" style="width:100%;margin-top:0.5rem;"></audio>`;
+      return `<a href="${m}" target="_blank">Download file</a>`;
+    }).join('');
+    modal.innerHTML=`<div class=\"modal\"><div class=\"modal-content\"><div class=\"modal-header\"><h3>${j.title}</h3><span class=\"close\" onclick=\"closeModal()\">&times;</span></div><div class=\"modal-body\"><p><strong>Date:</strong> ${j.date}</p><p><strong>Type:</strong> ${t?t.name:''}</p><p>${j.text}</p>${mediaHtml}</div><div class=\"modal-footer\" style=\"text-align:right\"><button class=\"btn\" onclick=\"deleteJournal(${j.id})\">Delete</button></div></div></div>`;
+  modal.classList.remove('hidden');
+}
+
+function deleteJournal(id){
+  journals=journals.filter(j=>j.id!==id);
+  renderJournals();
+  saveSoul();
+  closeModal();
+}
+
+/* Motto functions */
+function addMotto(){
+  const name=document.getElementById('mottoName').value.trim();
+  const text=document.getElementById('mottoText').value.trim();
+  if(!name || !text) return;
+  mottos.push({id:nextMottoId++,name,text,readCount:0,lastRead:null});
+  document.getElementById('mottoName').value='';
+  document.getElementById('mottoText').value='';
+  renderMottos();
+  saveSoul();
+}
+
+function renderMottos(){
+  const container=document.getElementById('mottoList');
+  if(!mottos.length){ container.innerHTML='<p style="opacity:.7">No mottos yet.</p>'; return;}
+  container.innerHTML=mottos.map(m=>`<div class=\"motto-item\" onclick=\"viewMotto(${m.id})\"><strong>${m.name}</strong></div>`).join('');
+}
+
+function viewMotto(id){
+  const m=mottos.find(x=>x.id===id); if(!m) return;
+  const modal=document.getElementById('modalContainer');
+  modal.innerHTML=`<div class=\"modal\"><div class=\"modal-content\"><div class=\"modal-header\"><h3>${m.name}</h3><span class=\"close\" onclick=\"closeModal()\">&times;</span></div><div class=\"modal-body\"><p>${m.text}</p><p>Read ${m.readCount} times${m.lastRead? ' (last: '+m.lastRead+')':''}</p></div><div class=\"modal-footer\" style=\"text-align:right\"><button class=\"btn\" onclick=\"markMottoRead(${m.id})\">Read</button><button class=\"btn\" style=\"margin-left:0.5rem\" onclick=\"editMotto(${m.id})\">Edit</button><button class=\"btn\" style=\"margin-left:0.5rem\" onclick=\"deleteMotto(${m.id})\">Delete</button></div></div></div>`;
+  modal.classList.remove('hidden');
+}
+
+function markMottoRead(id){
+  const m=mottos.find(x=>x.id===id); if(!m) return;
+  m.readCount++; m.lastRead=new Date().toISOString().slice(0,10);
+  saveSoul();
+  viewMotto(id);
+}
+
+function deleteMotto(id){
+  mottos=mottos.filter(x=>x.id!==id);
+  renderMottos();
+  saveSoul();
+  closeModal();
+}
+
+function editMotto(id){
+  const m=mottos.find(x=>x.id===id); if(!m) return;
+  const modal=document.getElementById('modalContainer');
+  modal.innerHTML=`<div class=\"modal\"><div class=\"modal-content\"><div class=\"modal-header\"><h3>Edit ${m.name}</h3><span class=\"close\" onclick=\"closeModal()\">&times;</span></div><div class=\"modal-body form-grid\"><label>Name<input id=\"editMottoName\" value=\"${m.name}\"></label><label>Text<textarea id=\"editMottoText\">${m.text}</textarea></label><div style=\"grid-column:1/-1;text-align:right\"><button class=\"btn\" onclick=\"updateMotto(${m.id})\">Save</button><button class=\"btn\" style=\"margin-left:0.5rem\" onclick=\"deleteMotto(${m.id})\">Delete</button></div></div></div></div>`;
+  modal.classList.remove('hidden');
+}
+
+function updateMotto(id){
+  const m=mottos.find(x=>x.id===id); if(!m) return;
+  m.name=document.getElementById('editMottoName').value.trim();
+  m.text=document.getElementById('editMottoText').value.trim();
+  renderMottos();
+  saveSoul();
+  closeModal();
+}
+
+function closeModal(){
+  const modal=document.getElementById('modalContainer');
+  modal.classList.add('hidden');
+  modal.innerHTML='';
+}
+
+async function init(){
+  await loadSoul();
+  renderMeditations();
+  renderJournalTypeOptions();
+  renderJournals();
+  renderMottos();
+  loadPinnedSections();
+}
 document.addEventListener('DOMContentLoaded', init);
 </script>
 </body>

--- a/soulData.json
+++ b/soulData.json
@@ -1,4 +1,10 @@
 {
-  "projects": [],
-  "nextProjectId": 1
+  "meditations": [],
+  "nextMeditationId": 1,
+  "journalTypes": [],
+  "nextJournalTypeId": 1,
+  "journals": [],
+  "nextJournalId": 1,
+  "mottos": [],
+  "nextMottoId": 1
 }

--- a/styles.css
+++ b/styles.css
@@ -64,6 +64,7 @@ header h1 { font-size:clamp(3.9rem, 6vw, 6rem); background:none; color:var(--col
   border-radius:var(--radius-sm);
   margin-bottom:0.5rem;
   box-shadow:0 1px 2px rgba(44,44,44,0.04);
+  text-align:center;
 }
 .toggle {
   padding:0.5rem;
@@ -81,11 +82,47 @@ header h1 { font-size:clamp(3.9rem, 6vw, 6rem); background:none; color:var(--col
   .section-header {
     font-size:1.2rem;
     padding:0.7rem 1rem;
+    position:relative;
   }
   .section-header:hover {
     background:var(--color-header-bg);
     color:var(--color-header-text);
   }
+
+/* Add-item toggle banner */
+.add-toggle {
+  background: #2B2C29;
+  color: #C7BBB4;
+  font-size: 0.8rem;
+  padding: 0.5rem;
+  transition: all 0.2s ease;
+}
+.add-toggle:hover {
+  background: #C7BBB4;
+  color: #2B2C29;
+  box-shadow: 0 0 12px 2px #2B2C29;
+}
+
+/* Pinned section star */
+.section-header .pin-star {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  transform: translateY(-50%);
+  cursor: pointer;
+  z-index: 10;
+}
+
+.section-header .pin-star svg {
+  width: 16px;
+  height: 16px;
+}
+
+.section-header .pin-star.pinned svg {
+  fill: #F7F6F3;
+  stroke: #2B2C29;
+  stroke-width: 1;
+}
 
 /* Buttons */
 .btn { background:var(--color-btn-bg); color:var(--color-btn-text); border:none; padding:.55rem .9rem; font:inherit; border-radius:var(--radius-pill); cursor:pointer; font-weight:500; box-shadow:0 2px 4px rgba(0,0,0,.08); transition:var(--transition); }


### PR DESCRIPTION
## Summary
- add shared `.add-toggle` and pinned star styles to global stylesheet so soul page banners match index
- allow journal entries to upload and store media, showing thumbnails and links when viewing
- ensure server keeps journal `media` arrays when loading and saving soul data
- center soul section headers and add banners with correctly positioned pin stars
- simplify journal section with always-visible entry form and separate entry-type toggle

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a83644d0f4832f8d5f9bc4a14edf4e